### PR TITLE
feat(form): #MC-1 add default agenda to all users

### DIFF
--- a/src/main/java/net/atos/entng/calendar/Calendar.java
+++ b/src/main/java/net/atos/entng/calendar/Calendar.java
@@ -19,6 +19,7 @@
 
 package net.atos.entng.calendar;
 
+import fr.wseduc.mongodb.MongoDb;
 import fr.wseduc.webutils.Server;
 import io.vertx.core.DeploymentOptions;
 import net.atos.entng.calendar.controllers.CalendarController;
@@ -26,6 +27,8 @@ import net.atos.entng.calendar.controllers.EventController;
 import net.atos.entng.calendar.event.CalendarRepositoryEvents;
 import net.atos.entng.calendar.event.CalendarSearchingEvents;
 import net.atos.entng.calendar.ical.ICalHandler;
+import net.atos.entng.calendar.services.CalendarService;
+import net.atos.entng.calendar.services.impl.CalendarServiceImpl;
 import net.atos.entng.calendar.services.impl.EventServiceMongoImpl;
 import org.entcore.common.http.BaseServer;
 import org.entcore.common.http.filter.ShareAndOwner;
@@ -48,7 +51,8 @@ public class Calendar extends BaseServer {
     public void start() throws Exception {
         super.start();
         CrudService eventService = new EventServiceMongoImpl(CALENDAR_EVENT_COLLECTION, vertx.eventBus());
-        
+        CalendarService calendarService = new CalendarServiceImpl(CALENDAR_COLLECTION, MongoDb.getInstance());
+
         final MongoDbConf conf = MongoDbConf.getInstance();
         conf.setCollection(CALENDAR_COLLECTION);
         conf.setResourceIdLabel("id");
@@ -64,7 +68,7 @@ public class Calendar extends BaseServer {
         }
         EventBus eb = Server.getEventBus(vertx);
         final TimelineHelper timelineHelper = new TimelineHelper(vertx, eb, config);
-        addController(new CalendarController(CALENDAR_COLLECTION));
+        addController(new CalendarController(CALENDAR_COLLECTION, calendarService));
         addController(new EventController(CALENDAR_EVENT_COLLECTION, eventService, timelineHelper));
     }
     

--- a/src/main/java/net/atos/entng/calendar/event/CalendarRepositoryEvents.java
+++ b/src/main/java/net/atos/entng/calendar/event/CalendarRepositoryEvents.java
@@ -49,6 +49,7 @@ public class CalendarRepositoryEvents extends MongoDbRepositoryEvents {
         this.collectionNameToImportPrefixMap.put(Calendar.CALENDAR_EVENT_COLLECTION, "ev_");
     }
 
+
     @Override
     public void exportResources(JsonArray resourcesIds, boolean exportDocuments, boolean exportSharedResources, String exportId, String userId,
                                 JsonArray g, String exportPath, String locale, String host, Handler<Boolean> handler)

--- a/src/main/java/net/atos/entng/calendar/services/CalendarService.java
+++ b/src/main/java/net/atos/entng/calendar/services/CalendarService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © Région Nord Pas de Calais-Picardie,  Département 91, Région Aquitaine-Limousin-Poitou-Charentes, 2016.
+ *
+ * This file is part of OPEN ENT NG. OPEN ENT NG is a versatile ENT Project based on the JVM and ENT Core Project.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation (version 3 of the License).
+ *
+ * For the sake of explanation, any module that communicate over native
+ * Web protocols, such as HTTP, with OPEN ENT NG is outside the scope of this
+ * license and could be license under its own terms. This is merely considered
+ * normal use of OPEN ENT NG, and does not fall under the heading of "covered work".
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package net.atos.entng.calendar.services;
+
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpServerRequest;
+import org.entcore.common.user.UserInfos;
+import io.vertx.core.json.JsonObject;
+
+public interface CalendarService {
+
+    /**
+     * Has Default Calendar
+     *
+     * @param user User Object containing user id
+     * @return Future {@link Future<Boolean>} expressing if user already has a default calendar
+     */
+    Future<Boolean> hasDefaultCalendar(UserInfos user);
+
+    /**
+     * Create Default Calendar
+     *
+     * @param exists Boolean expressing if user already has a default calendar
+     * @param user User Object containing user id and displayed name
+     * @param request HTTP Server Request
+     * @return Future {@link Future<JsonObject>} containing newly created default calendar or empty
+     */
+    Future<JsonObject> createDefaultCalendar(Boolean exists, UserInfos user, HttpServerRequest request);
+
+}

--- a/src/main/java/net/atos/entng/calendar/services/impl/CalendarServiceImpl.java
+++ b/src/main/java/net/atos/entng/calendar/services/impl/CalendarServiceImpl.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © Région Nord Pas de Calais-Picardie,  Département 91, Région Aquitaine-Limousin-Poitou-Charentes, 2016.
+ *
+ * This file is part of OPEN ENT NG. OPEN ENT NG is a versatile ENT Project based on the JVM and ENT Core Project.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation (version 3 of the License).
+ *
+ * For the sake of explanation, any module that communicate over native
+ * Web protocols, such as HTTP, with OPEN ENT NG is outside the scope of this
+ * license and could be license under its own terms. This is merely considered
+ * normal use of OPEN ENT NG, and does not fall under the heading of "covered work".
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+package net.atos.entng.calendar.services.impl;
+import static fr.wseduc.webutils.http.Renders.getHost;
+import static org.entcore.common.mongodb.MongoDbResult.*;
+
+import fr.wseduc.webutils.I18n;
+import fr.wseduc.webutils.http.Renders;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import net.atos.entng.calendar.services.CalendarService;
+
+import org.entcore.common.user.UserInfos;
+import io.vertx.core.json.JsonObject;
+
+import com.mongodb.QueryBuilder;
+
+import fr.wseduc.mongodb.MongoDb;
+import fr.wseduc.mongodb.MongoQueryBuilder;
+
+
+
+public class CalendarServiceImpl implements CalendarService {
+    private MongoDb mongo;
+    private String collection;
+    protected static final Logger log = LoggerFactory.getLogger(CalendarServiceImpl.class);
+
+
+    public CalendarServiceImpl(String collection, MongoDb mongo) {
+        this.collection = collection;
+        this.mongo = mongo;
+    }
+
+    @Override
+    public Future<Boolean> hasDefaultCalendar(UserInfos user) {
+        Promise<Boolean> promise = Promise.promise();
+        // Query
+        QueryBuilder query = QueryBuilder.start("owner.userId").is(user.getUserId());
+        query.put("is_default").is(true);
+
+        mongo.findOne(this.collection, MongoQueryBuilder.build(query), validResultHandler(result -> {
+            if(result.isLeft()) {
+                log.error("[Calendar@CalendarService::hasDefaultCalendar]: an error has occurred while finding default calendar: ",
+                        result.left().getValue());
+                promise.fail(result.left().getValue());
+                return;
+            }
+            promise.complete(!result.right().getValue().isEmpty());
+        }));
+        return promise.future();
+    }
+
+    @Override
+    public Future<JsonObject> createDefaultCalendar(Boolean exists, UserInfos user, HttpServerRequest request) {
+        Promise<JsonObject> promise = Promise.promise();
+
+        if (!exists) {
+            JsonObject defaultCalendar = new JsonObject();
+            JsonObject now = MongoDb.now();
+
+            String title = I18n.getInstance().translate("calendar.default.title", getHost(request), I18n.acceptLanguage(request));
+
+            defaultCalendar.put("title", title);
+            defaultCalendar.put("color", "grey");
+            defaultCalendar.put("created", now);
+            defaultCalendar.put("modified", now);
+            defaultCalendar.put("owner", new JsonObject().put("userId", user.getUserId()).put("displayName", user.getUsername()));
+            defaultCalendar.put("is_default", true);
+
+
+            insertDefaultCalendar(promise, defaultCalendar);
+        } else {
+            JsonObject response = new JsonObject();
+            promise.complete(response);
+        }
+        return promise.future();
+    }
+
+    /**
+     * Insert Default Calendar
+     *
+     * @param promise promise to complete or fail
+     * @param defaultCalendar JsonObject containing the data for the default calendar
+     */
+    private void insertDefaultCalendar(Promise<JsonObject> promise, JsonObject defaultCalendar) {
+        mongo.insert(this.collection, defaultCalendar, validActionResultHandler(result -> {
+            if(result.isLeft()) {
+                log.error("[Calendar@CalendarService::createDefaultCalendar]: an error has occurred while creating default calendar: ",
+                        result.left().getValue());
+                promise.fail(result.left().getValue());
+                return;
+            }
+            promise.complete(result.right().getValue());
+        }));
+    }
+
+
+}

--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -41,6 +41,7 @@
     "calendar.import": "Import",
     "calendar.export": "Export",
     "calendar.calendars.empty": "No calendar",
+    "calendar.default.title": "My calendar",
     "calendar.shared.calendars": "Shared calendars",
     "calendar.event.recurrence": "Recurrence",
     "calendar.ics.file.import.report": "ICS import file report",

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -39,6 +39,7 @@
     "calendar.import": "Importer",
     "calendar.export": "Exporter",
     "calendar.calendars.empty": "Pas d'agenda",
+    "calendar.default.title": "Mon agenda",
     "calendar.shared.calendars": "Agendas partagés",
     "calendar.event.recurrence": "Récurrence",
     "calendar.ics.file.import.report": "Rapport d'import de fichier ICS",

--- a/src/test/java/net/atos/entng/calendar/services/CalendarServiceImplTest.java
+++ b/src/test/java/net/atos/entng/calendar/services/CalendarServiceImplTest.java
@@ -1,0 +1,104 @@
+package net.atos.entng.calendar.services;
+
+import io.vertx.core.Promise;
+import net.atos.entng.calendar.Calendar;
+import net.atos.entng.calendar.services.impl.CalendarServiceImpl;
+import fr.wseduc.mongodb.MongoDb;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.entcore.common.user.UserInfos;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.reflect.Whitebox;
+
+import static org.mockito.Mockito.mock;
+
+@RunWith(VertxUnitRunner.class)
+public class CalendarServiceImplTest {
+
+    MongoDb mongo = mock(MongoDb.class);
+    private CalendarServiceImpl calendarService;
+
+    private static final String USER_ID = "000";
+
+    @Before
+    public void setUp(TestContext context) {
+
+        this.calendarService = new CalendarServiceImpl(Calendar.CALENDAR_COLLECTION, mongo);
+    }
+
+    @Test
+    public void testHasDefaultCalendarIfHasNoDefaultCalendar(TestContext context){
+        // Arguments
+        UserInfos user = new UserInfos();
+        user.setOtherProperty("owner", new JsonObject());
+        user.setUserId(USER_ID);
+
+        // Expected data
+        String expectedCollection = "calendar";
+        JsonObject expectedQuery = new JsonObject()
+                .put("owner.userId", USER_ID)
+                .put("is_default", true);
+
+        Mockito.doAnswer(invocation -> {
+            String collection = invocation.getArgument(0);
+            JsonObject query = invocation.getArgument(1);
+            context.assertEquals(collection, expectedCollection);
+            context.assertEquals(query, expectedQuery);
+            return null;
+        }).when(mongo).findOne(Mockito.anyString(), Mockito.any(JsonObject.class), Mockito.any(Handler.class));
+
+        calendarService.hasDefaultCalendar(user);
+    }
+
+    @Test
+    public void testCreateDefaultCalendarIfDoesNotExist(TestContext context){
+        JsonObject now = MongoDb.now();
+
+        // Arguments
+        Promise<JsonObject> promise = Promise.promise();
+
+        UserInfos user = new UserInfos();
+        user.setOtherProperty("owner", new JsonObject());
+        user.setUserId(USER_ID);
+
+        JsonObject defaultCalendar = new JsonObject();
+        defaultCalendar.put("title", "Mon agenda");
+        defaultCalendar.put("color", "grey");
+        defaultCalendar.put("created", now);
+        defaultCalendar.put("modified", now);
+        defaultCalendar.put("owner", new JsonObject().put("userId", "000").put("displayName", (String) null));
+        defaultCalendar.put("is_default", true);
+
+        // Expected data
+        String expectedCollection = "calendar";
+        JsonObject expectedCalendar = new JsonObject()
+                .put("title", "Mon agenda")
+                .put("color", "grey")
+                .put("created", now) //Date not @ same time
+                .put("modified", now)
+                .put("owner", new JsonObject()
+                        .put("userId", USER_ID)
+                        .put("displayName", (String) null)) //(String) null != null
+                .put("is_default", true);
+
+        Mockito.doAnswer(invocation -> {
+            String collection = invocation.getArgument(0);
+            JsonObject newCalendar = invocation.getArgument(1);
+            context.assertEquals(collection, expectedCollection);
+            context.assertEquals(newCalendar, expectedCalendar);
+            return null;
+        }).when(mongo).insert(Mockito.anyString(), Mockito.any(JsonObject.class), Mockito.any(Handler.class));
+
+        try {
+            Whitebox.invokeMethod(calendarService, "insertDefaultCalendar", promise, defaultCalendar);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+}


### PR DESCRIPTION
Quand l'utilisateur accède à la page 'Calendrier':
- on vérifie si il possède un agenda par défaut
- si il n'en possède pas, on crée un agenda par défaut "Mon agenda"
2 tests unitaires (1 par fonction)