### PR TITLE
feat(form): #MC-3 remove 'delete' button for default calendar

### DIFF
--- a/src/main/java/net/atos/entng/calendar/services/CalendarService.java
+++ b/src/main/java/net/atos/entng/calendar/services/CalendarService.java
@@ -44,4 +44,12 @@ public interface CalendarService {
      */
     Future<JsonObject> createDefaultCalendar(Boolean exists, UserInfos user, HttpServerRequest request);
 
+    /**
+     * Is Default Calendar
+     *
+     * @param calendarId String with the id of the calendar requested to be deleted
+     * @return Future {@link Future<Boolean>} telling if calendar can be deleted or not
+     */
+    Future<Boolean> isDefaultCalendar(String calendarId);
+
 }

--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -76,5 +76,6 @@
     "calendar.recurrent.event.remove": "Remove this event from recurrence",
     "calendar.event.not.all.calendar.rights": "You cannot modify this event because you do not have the necessary rights on one of the calendars.",
     "calendar.recurrent.event.delete.others": "Delete other events from recurrence",
-    "calendar.remove.all.recurrent": "Delete all the recurrence"
+    "calendar.remove.all.recurrent": "Delete all the recurrence",
+    "calendar.delete.error": "Default calendar cannot be deleted"
 }

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -115,6 +115,7 @@
     "calendar.recurrence.daymap.sat":"Sa",
     "calendar.recurrence.daymap.sun":"Di",
     "calendar.error.date.saving":"Problème d'enregistrement de l'évènement : Les dates de début et fin ne sont pas les mêmes, veuillez contacter le service support",
+    "calendar.delete.error": "Une erreur est survenue lors de la supression du calendrier",
     "calendar.navigation.guard": "Les modifications que vous avez apportées ne seront peut-être pas enregistrées. Souhaitez vous quitter cette page?",
     "calendar.event.not.all.calendar.rights": "Vous ne pouvez pas modifier cet événement car vous n'avez pas les droits nécessaire sur l'un des agendas.",
     "calendar.duration": "Durée",
@@ -122,5 +123,6 @@
     "calendar.event.remove.others.from.recurrence": "Supprimer les autres évènements de la récurrence",
     "calendar.event.remove.all.from.recurrence": "Supprimer tous les événements de la récurrence",
     "calendar.event.edit.select.one": "Sélectionner un agenda",
-    "calendar.event.edit.reccurrence.is": "La récurrence est:"
+    "calendar.event.edit.reccurrence.is": "La récurrence est:",
+    "cannot.delete.default.calendar": "Votre calendrier par défaut ne peut pas être supprimé"
 }

--- a/src/main/resources/public/sass/global/components/_index.scss
+++ b/src/main/resources/public/sass/global/components/_index.scss
@@ -3,3 +3,4 @@
 @import "jquery.timepicker";
 @import "timepicker";
 @import "fixCalendar";
+@import "toasts";

--- a/src/main/resources/public/sass/global/components/toasts.scss
+++ b/src/main/resources/public/sass/global/components/toasts.scss
@@ -1,0 +1,102 @@
+.toasts {
+  position: fixed;
+  top: 74px;
+  right: 25px;
+  width: 350px;
+  z-index: 1000;
+  box-sizing: border-box;
+
+  .toast-content {
+    //@include material-card();
+    margin-bottom: 10px;
+    position: relative;
+    opacity: 0;
+    margin-top: 40px;
+    box-sizing: border-box;
+    font-size: 16px !important;
+    border-left: none !important;
+    height: 0 !important;
+    overflow: hidden;
+    transition: all 0.25s ease;
+
+    .content {
+      padding: 15px 10px;
+      line-height: 28px;
+
+      &:before {
+        @include fonticon();
+        margin-right: 10px;
+      }
+    }
+
+    &.show {
+      margin-top: 10px !important;
+      opacity: 1;
+      height: auto !important;
+      overflow: auto !important;
+    }
+
+    &.confirm {
+      color: darken($green, 35%);
+      background-color: lighten($green, 30%);
+
+      .content:before {
+        content: '\e871';
+      }
+
+      .timer {
+        background-color: darken($green, 15%);
+      }
+    }
+
+    &.info {
+      color: darken($cyan, 35%);
+      background-color: lighten($cyan, 30%);
+
+      .content:before {
+        content: '\e84b';
+      }
+
+      .timer {
+        background-color: darken($cyan, 15%);
+      }
+    }
+
+    &.warning {
+      color: darken($warning-color, 35%);
+      background-color: lighten($warning-color, 30%);
+
+      .content:before {
+        content: '\e903';
+      }
+
+      .timer {
+        background-color: darken($warning-color, 15%);
+      }
+    }
+
+    &.info, &.warning {
+      .content:before {
+        font-size: 20px !important;
+      }
+    }
+
+    .timer {
+      width: 100%;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      height: 4px;
+      border-bottom-left-radius: 2px;
+      border-bottom-right-radius: 2px;
+      transition-timing-function: linear;
+      transition-property: all;
+      transition-duration: 3s;
+
+      &.animation {
+        width: 0;
+        border-bottom-right-radius: 0;
+      }
+    }
+  }
+}

--- a/src/main/resources/public/template/main-view.html
+++ b/src/main/resources/public/template/main-view.html
@@ -70,7 +70,7 @@
                     <a href="/calendar/[[showButtonsCalendar._id]]/ical"><button><i18n>calendar.export</i18n></button></a>
                     <button ng-click="displayImportIcsPanel()"><i18n>calendar.import</i18n></button>
                     <button ng-click="editCalendar(showButtonsCalendar, $event)"><i18n>edit</i18n></button>
-                    <button ng-click="confirmRemoveCalendar(showButtonsCalendar, $event)"><i18n>remove</i18n></button>
+                    <button ng-click="confirmRemoveCalendar(showButtonsCalendar, $event)" ng-if="canBeDeleted()"><i18n>remove</i18n></button>
                     <button ng-click="shareCalendar(showButtonsCalendar, $event)"><i18n>share</i18n></button>
             </behaviour>
         </div>

--- a/src/main/resources/public/ts/model/__tests__/calendar.test.ts
+++ b/src/main/resources/public/ts/model/__tests__/calendar.test.ts
@@ -1,0 +1,22 @@
+import {Calendar} from "../Calendar";
+jest.mock('entcore')
+import axios, {AxiosRequestConfig} from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+describe('Calendar Model', () => {
+    const calendar = Object.create(Calendar.prototype, {
+        '_id': {value: '5'},
+        'myRights': {}
+    })
+    it('should return data when delete with Calendar is correctly called', () => {
+        let mock = new MockAdapter(axios);
+        const data = {response: true};
+        let correctData;
+        let id = '5'
+        mock.onDelete('/calendar/' + id).reply(
+            (_: AxiosRequestConfig) => new Promise(() => correctData = data)
+        );
+        calendar.delete().then(response => {
+            expect(correctData).toEqual(data);
+        });
+    });
+});

--- a/src/test/java/net/atos/entng/calendar/services/CalendarServiceImplTest.java
+++ b/src/test/java/net/atos/entng/calendar/services/CalendarServiceImplTest.java
@@ -24,6 +24,7 @@ public class CalendarServiceImplTest {
     private CalendarServiceImpl calendarService;
 
     private static final String USER_ID = "000";
+    private static final String CALENDAR_ID = "111";
 
     @Before
     public void setUp(TestContext context) {
@@ -99,6 +100,26 @@ public class CalendarServiceImplTest {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    @Test
+    public void testIsDefaultCalendarIfIsNotDefaultCalendar(TestContext context){
+
+        // Expected data
+        String expectedCollection = "calendar";
+        JsonObject expectedQuery = new JsonObject()
+                .put("_id", CALENDAR_ID)
+                .put("is_default", true);
+
+        Mockito.doAnswer(invocation -> {
+            String collection = invocation.getArgument(0);
+            JsonObject query = invocation.getArgument(1);
+            context.assertEquals(collection, expectedCollection);
+            context.assertEquals(query, expectedQuery);
+            return null;
+        }).when(mongo).findOne(Mockito.anyString(), Mockito.any(JsonObject.class), Mockito.any(Handler.class));
+
+        calendarService.isDefaultCalendar(CALENDAR_ID);
     }
 
 }


### PR DESCRIPTION
- le bouton 'supprimer' n'apparait pas quand le calendrier sélectionné est le calendrier par défaut
- si un appel au back est quand même effectué, on renvoie une HTTP 403 et un toast s'affiche pour prévenir l'utilisateur que le calendrier par défaut ne peut pas être supprimé
- message d'erreur si il y a une erreur autre durant la supression
- tests unitaires back+front