### PR TITLE
feat(share): #MC-2 allow to share events

### DIFF
--- a/src/main/java/net/atos/entng/calendar/Calendar.java
+++ b/src/main/java/net/atos/entng/calendar/Calendar.java
@@ -28,21 +28,24 @@ import net.atos.entng.calendar.event.CalendarRepositoryEvents;
 import net.atos.entng.calendar.event.CalendarSearchingEvents;
 import net.atos.entng.calendar.ical.ICalHandler;
 import net.atos.entng.calendar.services.CalendarService;
+import net.atos.entng.calendar.services.ServiceFactory;
 import net.atos.entng.calendar.services.impl.CalendarServiceImpl;
 import net.atos.entng.calendar.services.impl.EventServiceMongoImpl;
 import org.entcore.common.http.BaseServer;
 import org.entcore.common.http.filter.ShareAndOwner;
 import org.entcore.common.mongodb.MongoDbConf;
+import org.entcore.common.neo4j.Neo4j;
 import org.entcore.common.notification.TimelineHelper;
 import org.entcore.common.service.CrudService;
 import io.vertx.core.eventbus.EventBus;
+import org.entcore.common.sql.Sql;
 
 
 public class Calendar extends BaseServer {
-    public final static String CALENDAR_NAME = "CALENDAR";
+    public static final String CALENDAR_NAME = "CALENDAR";
 
-    public final static String CALENDAR_COLLECTION = "calendar";
-    public final static String CALENDAR_EVENT_COLLECTION = "calendarevent";
+    public static final String CALENDAR_COLLECTION = "calendar";
+    public static final String CALENDAR_EVENT_COLLECTION = "calendarevent";
 
     public static final String MANAGE_RIGHT_ACTION = "net-atos-entng-calendar-controllers-CalendarController|updateCalendar";
 
@@ -51,7 +54,7 @@ public class Calendar extends BaseServer {
     public void start() throws Exception {
         super.start();
         CrudService eventService = new EventServiceMongoImpl(CALENDAR_EVENT_COLLECTION, vertx.eventBus());
-        CalendarService calendarService = new CalendarServiceImpl(CALENDAR_COLLECTION, MongoDb.getInstance());
+        ServiceFactory serviceFactory = new ServiceFactory(vertx, Neo4j.getInstance(), Sql.getInstance(), MongoDb.getInstance());
 
         final MongoDbConf conf = MongoDbConf.getInstance();
         conf.setCollection(CALENDAR_COLLECTION);
@@ -68,8 +71,8 @@ public class Calendar extends BaseServer {
         }
         EventBus eb = Server.getEventBus(vertx);
         final TimelineHelper timelineHelper = new TimelineHelper(vertx, eb, config);
-        addController(new CalendarController(CALENDAR_COLLECTION, calendarService));
-        addController(new EventController(CALENDAR_EVENT_COLLECTION, eventService, timelineHelper));
+        addController(new CalendarController(CALENDAR_COLLECTION, serviceFactory));
+        addController(new EventController(CALENDAR_EVENT_COLLECTION, eventService, serviceFactory, timelineHelper));
     }
     
 }

--- a/src/main/java/net/atos/entng/calendar/helpers/FutureHelper.java
+++ b/src/main/java/net/atos/entng/calendar/helpers/FutureHelper.java
@@ -1,0 +1,22 @@
+package net.atos.entng.calendar.helpers;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.impl.CompositeFutureImpl;
+
+import java.util.List;
+
+public class FutureHelper {
+
+    private FutureHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static <T> CompositeFuture all(List<Future<T>> futures) {
+        return CompositeFutureImpl.all(futures.toArray(new Future[0]));
+    }
+
+    public static <T> CompositeFuture join(List<Future<T>> futures) {
+        return CompositeFutureImpl.join(futures.toArray(new Future[0]));
+    }
+}

--- a/src/main/java/net/atos/entng/calendar/helpers/UserHelper.java
+++ b/src/main/java/net/atos/entng/calendar/helpers/UserHelper.java
@@ -1,0 +1,31 @@
+package net.atos.entng.calendar.helpers;
+
+import io.vertx.core.json.JsonArray;
+import net.atos.entng.calendar.models.User;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UserHelper {
+
+    private UserHelper() { throw new IllegalStateException("Helper class"); }
+
+    /**
+     * "convert" Array widgets into list User {@link User}
+     *
+     * using "for loop" instead of .stream() since this JsonArray is filled with LinkedHashMap instead of JsonObject
+     * else .stream() might encounter "LinkedHashMap" cannot cast to JsonObject
+     *
+     * @param usersArray                List of user {@link JsonArray}
+     * @return  {@link List<User>}      List of user with model
+     */
+    public static List<User> usersList(JsonArray usersArray) {
+        List<User> usersList = new ArrayList<>();
+        for (int i = 0; i < usersArray.size(); i++) {
+            User user = new User(usersArray.getJsonObject(i));
+            usersList.add(user);
+        }
+        return usersList;
+    }
+
+}

--- a/src/main/java/net/atos/entng/calendar/models/User.java
+++ b/src/main/java/net/atos/entng/calendar/models/User.java
@@ -1,0 +1,22 @@
+package net.atos.entng.calendar.models;
+
+import io.vertx.core.json.JsonObject;
+
+public class User {
+
+    private final String id;
+    private final String displayName;
+
+    public User(JsonObject user) {
+        this.id = user.getString("id", "");
+        this.displayName = user.getString("displayName", "");
+    }
+
+    public String id() {
+        return this.id;
+    }
+
+    public String displayName() {
+        return this.displayName;
+    }
+}

--- a/src/main/java/net/atos/entng/calendar/security/ShareEventConf.java
+++ b/src/main/java/net/atos/entng/calendar/security/ShareEventConf.java
@@ -1,0 +1,54 @@
+package net.atos.entng.calendar.security;
+
+import com.mongodb.DBObject;
+import com.mongodb.QueryBuilder;
+import fr.wseduc.mongodb.MongoQueryBuilder;
+import fr.wseduc.webutils.http.Binding;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import net.atos.entng.calendar.Calendar;
+import org.entcore.common.http.filter.MongoAppFilter;
+import org.entcore.common.http.filter.ResourcesProvider;
+import org.entcore.common.mongodb.MongoDbConf;
+import org.entcore.common.user.UserInfos;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ShareEventConf implements ResourcesProvider {
+
+    private MongoDbConf conf = MongoDbConf.getInstance();
+
+    @Override
+    public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
+        String id = request.params().get(conf.getResourceIdLabel());
+        if (id != null && !id.trim().isEmpty()) {
+            List<DBObject> groups = new ArrayList<>();
+            String sharedMethod = binding.getServiceMethod().replaceAll("\\.", "-");
+            groups.add(QueryBuilder.start("userId").is(user.getUserId())
+                    .put(sharedMethod).is(true).get());
+            for (String gpId: user.getGroupsIds()) {
+                groups.add(QueryBuilder.start("groupId").is(gpId)
+                        .put(sharedMethod).is(true).get());
+            }
+
+            QueryBuilder query = QueryBuilder.start("_id").is(id).or(
+                    QueryBuilder.start("owner.userId").is(user.getUserId()).get(),
+                    QueryBuilder.start("shared").elemMatch(
+                            new QueryBuilder().or(groups.toArray(new DBObject[groups.size()])).get()).get()
+            );
+
+
+            MongoAppFilter.executeCountQuery(request, conf.getCollection(), MongoQueryBuilder.build(query), 1, cal-> {
+                if (Boolean.TRUE.equals(cal) && cal) {
+                    handler.handle(true);
+                } else {
+                    MongoAppFilter.executeCountQuery(request, Calendar.CALENDAR_EVENT_COLLECTION, MongoQueryBuilder.build(query), 1, handler);
+                }
+            });
+
+        } else {
+                handler.handle(false);
+            }
+        }
+}

--- a/src/main/java/net/atos/entng/calendar/services/EventServiceMongo.java
+++ b/src/main/java/net/atos/entng/calendar/services/EventServiceMongo.java
@@ -40,6 +40,8 @@ public interface EventServiceMongo {
 
     void update(String calendarId, String eventId, JsonObject body, UserInfos user, Handler<Either<String, JsonObject>> handler);
 
+    void update(String eventId, JsonObject body, UserInfos user, Handler<Either<String, JsonObject>> handler);
+
     void delete(String calendarId, String eventId, UserInfos user, Handler<Either<String, JsonObject>> handler);
 
     void getIcal(String calendarId, UserInfos user, Handler<Message<JsonObject>> handler);

--- a/src/main/java/net/atos/entng/calendar/services/ServiceFactory.java
+++ b/src/main/java/net/atos/entng/calendar/services/ServiceFactory.java
@@ -1,0 +1,40 @@
+package net.atos.entng.calendar.services;
+
+import fr.wseduc.mongodb.MongoDb;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import net.atos.entng.calendar.Calendar;
+import net.atos.entng.calendar.services.impl.CalendarServiceImpl;
+import net.atos.entng.calendar.services.impl.DefaultUserServiceImpl;
+import org.entcore.common.neo4j.Neo4j;
+import org.entcore.common.sql.Sql;
+
+public class ServiceFactory {
+    private final Vertx vertx;
+    private final Neo4j neo4j;
+    private final Sql sql;
+    private final MongoDb mongoDb;
+
+    public ServiceFactory(Vertx vertx, Neo4j neo4j, Sql sql, MongoDb mongoDb) {
+        this.vertx = vertx;
+        this.neo4j = neo4j;
+        this.sql = sql;
+        this.mongoDb = mongoDb;
+    }
+
+    public EventBus eventBus() {
+        return this.vertx.eventBus();
+    }
+
+    public Vertx vertx() {
+        return this.vertx;
+    }
+
+    public UserService userService() {
+        return new DefaultUserServiceImpl(neo4j);
+    }
+
+    public CalendarService calendarService() {
+       return new CalendarServiceImpl(Calendar.CALENDAR_COLLECTION, mongoDb);
+    }
+}

--- a/src/main/java/net/atos/entng/calendar/services/UserService.java
+++ b/src/main/java/net/atos/entng/calendar/services/UserService.java
@@ -19,43 +19,23 @@
 
 package net.atos.entng.calendar.services;
 
+
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonArray;
+import net.atos.entng.calendar.models.User;
 import org.entcore.common.user.UserInfos;
-import io.vertx.core.json.JsonObject;
 
 import java.util.List;
 
-public interface CalendarService {
-
-
-    Future<JsonArray> list(List<String> calendarIds);
+public interface UserService {
 
     /**
-     * Get Default Calendar
+     * fetch users from shared data
      *
-     * @param user {@link UserInfos}
-     * @return FutureObject containing calendar {@link JsonObject}
-     */
-    Future<JsonObject> getDefaultCalendar(UserInfos user);
-
-
-    /**
-     * Create Default Calendar
+     * @param ids             list of ids being user or group identifier {@link List<String>}
+     * @param user            user info (in this case, we using only its id) {@link UserInfos}
      *
-     * @param user User Object containing user id and displayed name
-     * @param host domain host
-     * @param lang accepted lang
-     * @return Future {@link Future<JsonObject>} containing newly created default calendar or empty
+     * @return {@link Future} of {@link List<User>} containing list of user fetched
      */
-    Future<JsonObject> createDefaultCalendar(UserInfos user, String host, String lang);
-
-    /**
-     * Is Default Calendar
-     *
-     * @param calendarId String with the id of the calendar requested to be deleted
-     * @return Future {@link Future<Boolean>} telling if calendar can be deleted or not
-     */
-    Future<Boolean> isDefaultCalendar(String calendarId);
-
+    Future<List<User>> fetchUser(List<String> ids, UserInfos user);
 }
+

--- a/src/main/java/net/atos/entng/calendar/services/impl/DefaultUserServiceImpl.java
+++ b/src/main/java/net/atos/entng/calendar/services/impl/DefaultUserServiceImpl.java
@@ -1,0 +1,94 @@
+package net.atos.entng.calendar.services.impl;
+
+import fr.wseduc.webutils.collections.Joiner;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import net.atos.entng.calendar.helpers.UserHelper;
+import net.atos.entng.calendar.models.User;
+import net.atos.entng.calendar.services.UserService;
+import org.entcore.common.neo4j.Neo4j;
+import org.entcore.common.neo4j.Neo4jResult;
+import org.entcore.common.user.UserInfos;
+
+import java.util.List;
+
+public class DefaultUserServiceImpl implements UserService {
+
+    private final Neo4j neo4j;
+    private static final Logger log = LoggerFactory.getLogger(DefaultUserServiceImpl.class);
+
+    public DefaultUserServiceImpl(Neo4j neo4j) {
+        this.neo4j = neo4j;
+    }
+
+    /**
+     * fetch users from shared data
+     *
+     * @param ids             list of ids being user or group identifier {@link List<String>}
+     * @param user            user info (in this case, we using only its id) {@link UserInfos}
+     *
+     * @return {@link Future} of {@link List<User>} containing list of user fetched
+     */
+    @Override
+    public Future<List<User>> fetchUser(List<String> ids, UserInfos user) {
+        Promise<List<User>> promise = Promise.promise();
+        JsonObject param = new JsonObject().put("userId", user.getUserId());
+        neo4j.execute(getShareIdUserGroupInfoQuery(ids), param, Neo4jResult.validResultHandler(res -> {
+            if (res.isLeft()) {
+                String message = String.format("[Calendar@%s::fetchUser] An error has occured" +
+                        " during fetch users from its id/groups: %s", this.getClass().getSimpleName(), res.left().getValue());
+                log.error(message);
+                promise.fail(res.left().getValue());
+            } else {
+                promise.complete(UserHelper.usersList(res.right().getValue()));
+            }
+        }));
+        return promise.future();
+    }
+
+    /**
+     * Neo4j Query to fetch all user and belonged groups
+     *
+     * @param ids             list of ids being user or group identifier {@link List<String>}
+     *
+     * @return {@link String} of neo4j Query
+     */
+    private String getShareIdUserGroupInfoQuery(List<String> ids) {
+        return "MATCH (u:User) " +
+                        "WHERE u.id IN ['" +
+                        Joiner.on("','").join(ids) + "'] AND u.id <> {userId} " +
+                        "RETURN distinct u.id as id, u.displayName as displayName"
+
+                        + " UNION " +
+
+                        "MATCH (n:ProfileGroup )<-[:IN]-(u:User) " +
+                        "WHERE n.id IN ['" +
+                        Joiner.on("','").join(ids) + "'] AND u.id <> {userId} " +
+                        "RETURN distinct u.id as id, u.displayName as displayName"
+
+                        + " UNION " +
+
+                        "MATCH (n:ManualGroup )<-[:IN]-(u:User) " +
+                        "WHERE n.id IN ['" +
+                        Joiner.on("','").join(ids) + "'] AND u.id <> {userId} " +
+                        "RETURN distinct u.id as id, u.displayName as displayName"
+
+                        + " UNION " +
+
+                        "MATCH (n:CommunityGroup )<-[:IN]-(u:User) " +
+                        "WHERE n.id IN ['" +
+                        Joiner.on("','").join(ids) + "'] AND u.id <> {userId} " +
+                        "RETURN distinct u.id as id, u.displayName as displayName"
+
+                        + " UNION " +
+
+                        "MATCH (n:Group )<-[:IN]-(u:User) " +
+                        "WHERE n.id IN ['" +
+                        Joiner.on("','").join(ids) + "'] AND u.id <> {userId} " +
+                        "RETURN distinct u.id as id, u.displayName as displayName";
+    }
+
+}

--- a/src/main/java/net/atos/entng/calendar/services/impl/EventServiceMongoImpl.java
+++ b/src/main/java/net/atos/entng/calendar/services/impl/EventServiceMongoImpl.java
@@ -141,6 +141,24 @@ public class EventServiceMongoImpl extends MongoDbCrudService implements EventSe
     }
 
     @Override
+    public void update(String eventId, JsonObject body, UserInfos user, Handler<Either<String, JsonObject>> handler) {
+        // Query
+        QueryBuilder query = QueryBuilder.start("_id").is(eventId);
+
+        // Clean data
+        body.remove("_id");
+
+        // Modifier
+        MongoUpdateBuilder modifier = new MongoUpdateBuilder();
+        for (String attr : body.fieldNames()) {
+            modifier.set(attr, body.getValue(attr));
+        }
+        modifier.set("modified", MongoDb.now());
+        mongo.update(this.collection, MongoQueryBuilder.build(query), modifier.build(), validActionResultHandler(handler));
+
+    }
+
+    @Override
     public void delete(String calendarId, String eventId, UserInfos user, Handler<Either<String, JsonObject>> handler) {
         QueryBuilder query = QueryBuilder.start("_id").is(eventId);
         query.put("calendar").is(calendarId);

--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -77,5 +77,8 @@
     "calendar.event.not.all.calendar.rights": "You cannot modify this event because you do not have the necessary rights on one of the calendars.",
     "calendar.recurrent.event.delete.others": "Delete other events from recurrence",
     "calendar.remove.all.recurrent": "Delete all the recurrence",
-    "calendar.delete.error": "Default calendar cannot be deleted"
+    "calendar.delete.error": "Default calendar cannot be deleted",
+    "calendar.event.save.and.share": "Save and share",
+    "calendar.share.recurrence.only.first": "Only the first recurrence of this event will be shared.",
+    "calendar.event.save.error": "Error when saving the event."
 }

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -124,5 +124,8 @@
     "calendar.event.remove.all.from.recurrence": "Supprimer tous les événements de la récurrence",
     "calendar.event.edit.select.one": "Sélectionner un agenda",
     "calendar.event.edit.reccurrence.is": "La récurrence est:",
-    "cannot.delete.default.calendar": "Votre calendrier par défaut ne peut pas être supprimé"
+    "cannot.delete.default.calendar": "Votre calendrier par défaut ne peut pas être supprimé",
+    "calendar.event.save.and.share": "Enregistrer et partager",
+    "calendar.share.recurrence.only.first": "Seule la première récurrence de cet évènement sera partagée.",
+    "calendar.event.save.error": "Problème d'enregistrement de l'évènement."
 }

--- a/src/main/resources/public/template/edit-event.html
+++ b/src/main/resources/public/template/edit-event.html
@@ -336,6 +336,10 @@
                     ng-disabled="form.$invalid || calendarEvent.startMoment > calendarEvent.endMoment || !isCalendarSelectedInEvent()">
                 <i18n>save</i18n>
             </button>
+            <button class="right-magnet" ng-click="saveAndShareEvent(calendarEvent, $event)"
+                    ng-disabled="form.$invalid || calendarEvent.startMoment > calendarEvent.endMoment || !isCalendarSelectedInEvent()">
+                <i18n>calendar.event.save.and.share</i18n>
+            </button>
 
         </form>
     </section>

--- a/src/main/resources/public/template/main-view.html
+++ b/src/main/resources/public/template/main-view.html
@@ -71,7 +71,7 @@
                     <button ng-click="displayImportIcsPanel()"><i18n>calendar.import</i18n></button>
                     <button ng-click="editCalendar(showButtonsCalendar, $event)"><i18n>edit</i18n></button>
                     <button ng-click="confirmRemoveCalendar(showButtonsCalendar, $event)" ng-if="canBeDeleted()"><i18n>remove</i18n></button>
-                    <button ng-click="shareCalendar(showButtonsCalendar, $event)"><i18n>share</i18n></button>
+                    <button ng-if="!showButtonsCalendar.is_default" ng-click="shareCalendar(showButtonsCalendar, $event)"><i18n>share</i18n></button>
             </behaviour>
         </div>
     </div>
@@ -87,15 +87,23 @@
                 <button ng-if="calendarEvents.selected.length === 1 && calendarEvents.selected[0].parentId &&
                 calendarEvents.selected[0].isRecurrent" ng-click="deleteAllRecurrenceList(calendarEvents.selected[0])">
                     <i18n>calendar.remove.all.recurrent</i18n></button>
+                <button ng-if="calendarEvents.selected.length === 1" ng-click="shareEvent(calendarEvents.selected[0], $event)"><i18n>share</i18n></button>
             </behaviour>
         </div>
     </div>
 </section>
 
 <!-- Lightbox : Share calendar -->
-<div ng-if="display.showPanel">
-    <lightbox show="display.showPanel" on-close="display.showPanel = false;">
-        <share-panel app-prefix="'calendar'" resources="calendar"></share-panel>
+<div ng-if="display.showPanelCalendar">
+    <lightbox show="display.showPanelCalendar" on-close="display.showPanelCalendar = false;">
+        <share-panel app-prefix="'calendar'" resources="calendar" auto-close="true"></share-panel>
+    </lightbox>
+</div>
+
+<!-- Lightbox : Share event -->
+<div ng-if="display.showPanelEvent" class="absolute-magnet">
+    <lightbox show="display.showPanelEvent" on-close="display.showPanelEvent = false;">
+        <share-panel app-prefix="'calendar/calendarevent'" resources="calendarEvent" auto-close="true"></share-panel>
     </lightbox>
 </div>
 

--- a/src/main/resources/public/ts/behaviours.ts
+++ b/src/main/resources/public/ts/behaviours.ts
@@ -2,6 +2,8 @@ import { Behaviours, model, _ } from 'entcore';
 import http from "axios";
 import { CalendarEvent } from "./model";
 
+console.log("behaviours");
+
 const calendarBehaviours = {
 	resources: {
 		contrib: {
@@ -35,8 +37,7 @@ Behaviours.register('calendar', {
 				model.me.userId === rightsContainer.owner.userId) {
 				if (resource.myRights[behaviour] !== undefined) {
 					resource.myRights[behaviour] = resource.myRights[behaviour] && calendarBehaviours.resources[behaviour];
-				}
-				else {
+				} else {
 					resource.myRights[behaviour] = calendarBehaviours.resources[behaviour];
 				}
 			}

--- a/src/main/resources/public/ts/model/__tests__/calendar-event.test.ts
+++ b/src/main/resources/public/ts/model/__tests__/calendar-event.test.ts
@@ -4,7 +4,10 @@ import MockAdapter from 'axios-mock-adapter';
 
 describe('CalendarEvent', () => {
 
-    const calendarEvent = new CalendarEvent();
+
+    const calendarEvent = Object.create(CalendarEvent.prototype, {
+        'myRights': {}
+    })
 
     it('should return data when delete with calendarEvent is correctly called', () => {
         let mock = new MockAdapter(axios);

--- a/src/test/java/net/atos/entng/calendar/services/CalendarServiceImplTest.java
+++ b/src/test/java/net/atos/entng/calendar/services/CalendarServiceImplTest.java
@@ -53,7 +53,7 @@ public class CalendarServiceImplTest {
             return null;
         }).when(mongo).findOne(Mockito.anyString(), Mockito.any(JsonObject.class), Mockito.any(Handler.class));
 
-        calendarService.hasDefaultCalendar(user);
+        calendarService.getDefaultCalendar(user);
     }
 
     @Test


### PR DESCRIPTION
- Un utilisateur peut partager un évènement en utilisant le share-panel d'ODE
-  Choix de conception:
     -  [Faisabilité]: il n'est pas possible de restreindre le partage d'un évènement au sein d'un groupe
     - si on partage un évènement E d'un calendrier C avec un utilisateur avec qui C est déjà partagé, il ne se passe rien puisqu'il a déjà accès à l'évènement.
     - Bouton 'Enregister et partager' (accessible depuis la vue d'édition de l'évènement)
     - Bouton 'Partager' (accessible depuis la vue de liste de l'évènement, disparait quand plus d'un évènement est sélectionné)
     - Il n'est pas possible de partager un calendrier par défaut (front)