### PR TITLE
feat(form): #MC-31 change share button name depending on calendar shared or not

### DIFF
--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -78,7 +78,8 @@
     "calendar.recurrent.event.delete.others": "Delete other events from recurrence",
     "calendar.remove.all.recurrent": "Delete all the recurrence",
     "calendar.delete.error": "Default calendar cannot be deleted",
-    "calendar.event.save.and.share": "Save and restrict",
+    "calendar.event.save.and.restrict": "Save and restrict",
+    "calendar.event.save.and.share": "Save and share",
     "calendar.share.recurrence.only.first": "Only the first recurrence of this event will be shared.",
     "calendar.event.save.error": "Error when saving the event."
 }

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -125,7 +125,8 @@
     "calendar.event.edit.select.one": "Sélectionner un agenda",
     "calendar.event.edit.reccurrence.is": "La récurrence est:",
     "cannot.delete.default.calendar": "Votre calendrier par défaut ne peut pas être supprimé",
-    "calendar.event.save.and.share": "Enregistrer et restreindre",
+    "calendar.event.save.and.restrict": "Enregistrer et restreindre",
+    "calendar.event.save.and.share": "Enregistrer et partager",
     "calendar.share.recurrence.only.first": "Seule la première récurrence de cet évènement sera partagée.",
     "calendar.event.save.error": "Problème d'enregistrement de l'évènement."
 }

--- a/src/main/resources/public/template/edit-event.html
+++ b/src/main/resources/public/template/edit-event.html
@@ -339,7 +339,7 @@
             </button>
             <button class="right-magnet" ng-click="saveAndShareEvent(calendarEvent, $event)"
                     ng-disabled="form.$invalid || calendarEvent.startMoment > calendarEvent.endMoment || !isCalendarSelectedInEvent() || !hasRightOnSharedEvent(calendarEvent, rights.resources.shareEvent.right)">
-                <i18n>calendar.event.save.and.share</i18n>
+                [[nameOfShareButton(calendarEvent)]]
             </button>
 
         </form>

--- a/src/main/resources/public/ts/controllers/controller.ts
+++ b/src/main/resources/public/ts/controllers/controller.ts
@@ -817,6 +817,16 @@ export const calendarController =  ng.controller('CalendarController',
         };
     }
 
+    $scope.nameOfShareButton = (calendarEvent) : string => {
+        let numberOfSharedCalendars = calendarEvent.calendar
+            .filter((calendar:Calendar): boolean => calendar.shared && (calendar.shared.length !== 0))
+            .length;
+
+        return (numberOfSharedCalendars === 0)?
+            lang.translate('calendar.event.save.and.share') :
+            lang.translate('calendar.event.save.and.restrict');
+    }
+
     $scope.createCalendarEvent = newItem => {
         $scope.calendarAsContribRight = new Array<String>();
         $scope.selectedCalendarInEvent = new Array<String>();


### PR DESCRIPTION
Dynamic function that changes the name of the share button depending on the calendars the event is in.

Creating/Editing an event that is in at least one shared calendar:
Button name = "Enregistrer et restreindre"
Creating/Editing an event that is in non-shared calendar(s) :
Button name = "Enregistrer et partager"

Button changes during creation depending on the selected calendars