### PR TITLE
fix(view): #MC-5 place calendar and calendar icon

### DIFF
--- a/src/main/resources/public/sass/global/components/calendar.scss
+++ b/src/main/resources/public/sass/global/components/calendar.scss
@@ -26,7 +26,7 @@
     background-color: #ec6045 !important;
 }
 .color-selector .cyan, .row .cyan , nav.vertical ul li a.cyan{
-    background-color: #23a3db !important;
+    background-color: $calendar-blue !important;
 }
 .color-selector .grey, .row .grey, nav.vertical ul li a.grey {
     background-color: #b7b8ba !important;
@@ -82,7 +82,6 @@ nav.vertical ul li a input.calendar-checkbox {
 }
 
 .filters div.dates div.cell {
-    margin-right: 20px;
     line-height: 40px;
     vertical-align: middle;
 }
@@ -126,6 +125,40 @@ calendar {
     .displayModeButtons {
         margin-top: 0;
     }
+
+    i.calendar {
+        padding-top: 15px;
+    }
+
+    legend, .legend>.month-day, button.cyan {
+        background: $calendar-blue !important;
+    }
+
+    button.previous-timeslots, button.next-timeslots {
+        margin-right: 0px;
+        margin-left: 0px;
+    }
+
+    .dates>i18n {
+        margin-left: 20px;
+    }
+
+    .dates>.date-picker-icon a {
+        width: 30px;
+        margin-left: 20px;
+    }
+}
+
+h1 a {
+    color: $calendar-blue !important;
+}
+
+.top-spacing-four {
+    margin-top: 0px !important;
+}
+
+input[type=text] {
+    padding-left: 29px;
 }
 
 

--- a/src/main/resources/public/sass/global/components/fixCalendar.scss
+++ b/src/main/resources/public/sass/global/components/fixCalendar.scss
@@ -8,6 +8,7 @@
 .datepicker{
   display: none;
 }
-.schedule {
-  margin-top: 70px !important;
+.schedule, .schedule list-view {
+  margin-top: 0px !important;
+  padding-top: 25px;
 }

--- a/src/main/resources/public/sass/global/components/sidebar.scss
+++ b/src/main/resources/public/sass/global/components/sidebar.scss
@@ -1,4 +1,5 @@
 .sidebar {
+
   &-title {
     background-color: $calendar-blue;
 


### PR DESCRIPTION
replace calendar & calendar icon
put 'ent blue' in place of all the other blues used
center timeslot buttons
replace list view dates & timepickers
![image](https://user-images.githubusercontent.com/85180705/135817609-c5bbc86e-672a-4d95-a9eb-ee53dfd53a96.png)
![image](https://user-images.githubusercontent.com/85180705/135817634-304a46d5-2788-46f6-b23e-1f04bfdacd03.png)
