### PR TITLE
fix(view): MC-41 deactivate empty title warning

### DIFF
--- a/src/main/resources/public/template/edit-event.html
+++ b/src/main/resources/public/template/edit-event.html
@@ -6,7 +6,7 @@
     </h2>
 
     <section class="twelve cell">
-        <form name="form">
+        <form name="form" id="event-form">
             <div class="row">
 
                 <!-- Event details -->

--- a/src/main/resources/public/ts/controllers/controller.ts
+++ b/src/main/resources/public/ts/controllers/controller.ts
@@ -1,4 +1,4 @@
-import {$, _, moment, ng, template, idiom as lang, notify, toasts} from "entcore";
+import {$, _, moment, ng, template, idiom as lang, notify, toasts, angular} from "entcore";
 
 import {
     Calendar,
@@ -532,6 +532,12 @@ export const calendarController =  ng.controller('CalendarController',
     };
 
     $scope.closeCalendarEvent = () => {
+        if(!$scope.calendarEvent.title){
+            $scope.eventForm = angular.element(document.getElementById("event-form")).scope();
+            $scope.eventForm.form.$setPristine();
+            $scope.eventForm.form.$setUntouched();
+            $scope.$apply();
+        }
         template.close('lightbox');
         $scope.showCalendarEventTimePicker = false;
         $scope.display.showEventPanel = false;


### PR DESCRIPTION
Warning is reset to pristine when a form is closed without having been saved
![image](https://user-images.githubusercontent.com/85180705/140314762-1ab21e18-c13a-4348-bc51-fc2d7580260e.png)
