### PR TITLE
fix(calendar): #MC-55 update calendar after sharing it

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "webpack-stream": "3.2.0",
     "file-saver": "2.0.1",
     "ical.js": "1.3.0",
-    "yargs": "^8.0.2"
+    "yargs": "^8.0.2",
+    "rxjs": "5.4.2"
   },
   "devDependencies": {
     "@types/angular": "^1.6.55",

--- a/src/main/resources/public/template/main-view.html
+++ b/src/main/resources/public/template/main-view.html
@@ -6,6 +6,7 @@
               on-show-calendar="showCalendar()"
               on-show-list="showList()"
               on-open-or-close-calendar="openOrCloseCalendar"
+              on-event-update-checkbox="eventSidebar$"
               class="cell three">
     </side-bar>
 </div>
@@ -74,7 +75,7 @@
 <!-- Lightbox : Share calendar -->
 <div ng-if="display.showPanelCalendar">
     <lightbox show="display.showPanelCalendar" on-close="display.showPanelCalendar = false;">
-        <share-panel app-prefix="'calendar'" resources="calendar" auto-close="true"></share-panel>
+        <share-panel app-prefix="'calendar'" resources="calendar" auto-close="true" on-submit="updateCalendars()"></share-panel>
     </lightbox>
 </div>
 

--- a/src/main/resources/public/ts/directives/side-bar/side-bar.html
+++ b/src/main/resources/public/ts/directives/side-bar/side-bar.html
@@ -48,7 +48,7 @@
                                        ng-click="vm.onOpenOrCloseCalendar(cl, true)">
                                         <span>[[cl.title]]</span>
                                         <input type="checkbox" class="calendar-checkbox" ng-click="$event.stopPropagation();"
-                                               ng-model="cl.showButtons" ng-change="vm.hideOtherCalendarCheckboxes(cl)"/>
+                                               ng-model="cl.showButtons" ng-checked="cl.showButtons" ng-change="vm.hideOtherCalendarCheckboxes(cl)"/>
                                     </a>
                                 </li>
                             </ul>
@@ -62,7 +62,7 @@
                                        ng-click="vm.onOpenOrCloseCalendar(cl, true)">
                                         <span>[[cl.title]]</span>
                                         <input ng-if="cl.myRights.manage" type="checkbox" class="calendar-checkbox"
-                                               ng-click="$event.stopPropagationCallback();" ng-model="cl.showButtons"
+                                               ng-click="$event.stopPropagation();" ng-model="cl.showButtons" ng-checked="cl.showButtons"
                                                ng-change="vm.hideOtherCalendarCheckboxes(cl)"/>
                                         <span class="tooltip-top">
                                                 <i18n>calendar.owner</i18n> <span>[[cl.owner.displayName]]</span>

--- a/src/main/resources/public/ts/directives/side-bar/side-bar.ts
+++ b/src/main/resources/public/ts/directives/side-bar/side-bar.ts
@@ -1,14 +1,17 @@
 import { $, ng} from "entcore";
 import {Calendar, Calendars} from "../../model";
 import {ROOTS} from "../../core/const/roots";
-
+import {Subject} from "rxjs";
 
 interface IViewModel {
+    $onInit(): any;
 
+    // props
     calendars: Calendars;
     list: boolean;
-    calendar: Calendar;
     showButtonsCalendar: Calendar;
+    onEventUpdateCheckbox: Subject<void>;
+
 
     ownCalendars(): boolean;
     hasSharedCalendars(): boolean;
@@ -16,6 +19,9 @@ interface IViewModel {
     hideOtherCalendarCheckboxes(calendar): void;
     isMyCalendar(calendar: Calendar): void;
     isEmpty(): void;
+
+    //scope
+    calendar: Calendar;
 
     onShowCalendar(): void;
     onShowList(): void;
@@ -39,11 +45,21 @@ export const sideBar = ng.directive('sideBar', () =>{
         bindToController: {
             calendars: '=',
             showButtonsCalendar: '=',
-            list: "="
+            list: "=",
+            onEventUpdateCheckbox: '<'
         },
 
         controller: function (){
             const vm: IViewModel = <IViewModel>this;
+
+            vm.$onInit = () => {
+                if (vm.onEventUpdateCheckbox) {
+                    vm.onEventUpdateCheckbox.asObservable().subscribe(() => {
+                        vm.hideOtherCalendarCheckboxes(vm.calendar);
+                    });
+                }
+            };
+
         },
 
         link: function ($scope) {
@@ -51,7 +67,6 @@ export const sideBar = ng.directive('sideBar', () =>{
 
             vm.onShowCalendar = () : void => {
                 $scope.$eval($scope.onShowCalendar);
-
             };
 
             vm.onShowList = () : void => {


### PR DESCRIPTION
On closing of the share-panel/calendar edition panel:
- update of all the calendars (selected calendar is unselected by default)
- selected calendar is selected again 

method hideOtherCalendarCheckboxes is triggered using rxjs