### PR TITLE
feat(event): #MC-8 add multiple days events possibility

### DIFF
--- a/src/main/java/net/atos/entng/calendar/helpers/EventHelper.java
+++ b/src/main/java/net/atos/entng/calendar/helpers/EventHelper.java
@@ -28,7 +28,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -46,6 +50,7 @@ import net.atos.entng.calendar.services.EventServiceMongo;
 
 import net.atos.entng.calendar.services.ServiceFactory;
 import net.atos.entng.calendar.services.UserService;
+import net.atos.entng.calendar.utils.DateUtils;
 import org.entcore.common.events.EventStore;
 import org.entcore.common.events.EventStoreFactory;
 import org.entcore.common.mongodb.MongoDbControllerHelper;
@@ -115,7 +120,7 @@ public class EventHelper extends MongoDbControllerHelper {
                     RequestUtils.bodyToJson(request, new Handler<JsonObject>() {
                         @Override
                         public void handle(JsonObject object) {
-                            if (object.getString("notifStartMoment").substring(0,10).equals(object.getString("notifEndMoment").substring(0,10))) {
+                            if (isEventValid(object, request)) {
                                 eventService.create(calendarId, object, user, new Handler<Either<String, JsonObject>>() {
                                     public void handle(Either<String, JsonObject> event) {
                                         if (event.isRight()) {
@@ -135,7 +140,8 @@ public class EventHelper extends MongoDbControllerHelper {
                                     }
                                 });
                             }else{
-                                log.error("The beginning and end date of the event are not the same");
+                                log.error(String.format("[Calendar@EventHelper::create] " + "Submitted event is not valid"),
+                                        I18n.getInstance().translate("calendar.error.date.saving", getHost(request), I18n.acceptLanguage(request)));
                                 Renders.unauthorized(request);
                             }
                         }
@@ -410,6 +416,24 @@ public class EventHelper extends MongoDbControllerHelper {
                 }
             } // end  if (event.isRight())
         });
+    }
+
+    private boolean isEventValid (JsonObject object, HttpServerRequest request) {
+        Date startDate = DateUtils.parseDate(object.getString("startMoment"), DateUtils.DATE_FORMAT_UTC);
+        Date endDate = DateUtils.parseDate(object.getString("endMoment"), DateUtils.DATE_FORMAT_UTC);
+
+        boolean areDatesValid = DateUtils.isStrictlyBefore(startDate, endDate);
+        boolean isOneDayEvent = DateUtils.isSameDay(startDate, endDate);
+        boolean isNotRecurrentEvent = Boolean.FALSE.equals(object.getBoolean("isRecurrent"));
+
+        long dayInMilliseconds = 1000 * 60 * 60 * 24;
+        int eventDayLength = (int) ((endDate.getTime() - startDate.getTime())/dayInMilliseconds);
+
+        boolean isWeeklyRecurrenceValid = object.getValue("recurrence") instanceof JsonObject
+                && "every_week".equals(object.getJsonObject("recurrence").getValue("type"))
+                && (eventDayLength < (7 * object.getJsonObject("recurrence").getInteger("every")));
+
+        return (areDatesValid && (isOneDayEvent || isNotRecurrentEvent || isWeeklyRecurrenceValid));
     }
 
     /**

--- a/src/main/java/net/atos/entng/calendar/utils/DateUtils.java
+++ b/src/main/java/net/atos/entng/calendar/utils/DateUtils.java
@@ -1,0 +1,57 @@
+package net.atos.entng.calendar.utils;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+
+public final class DateUtils {
+
+    public static final String DATE_FORMAT = "yyyy-MM-dd";
+    public static final String DATE_FORMAT_UTC = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    public static final String FRENCH_DATE_FORMAT ="dd-MM-yyyy";
+    public static final String YEAR = "yyyy";
+    public static final String DAY_MONTH_YEAR_HOUR_TIME = "dd/MM/yyyy HH:mm:ss";
+    public static final String HOUR_MINUTE_SECOND = "HH:mm:ss";
+    public static final String HOUR_MINUTE = "HH:mm";
+
+    private DateUtils()  {}
+
+    public static Date parseDate(String dateToParse, String format) {
+        try {
+            SimpleDateFormat dateFormat = new SimpleDateFormat(format);
+            return dateFormat.parse(dateToParse);
+        } catch (ParseException e) {
+            return null;
+        }
+    }
+
+    public static Boolean isStrictlyBefore(Date d1, Date d2) {
+        if ((d1 == null) || (d2 == null)) {
+            return false;
+        }
+        return (d1.before(d2));
+    }
+
+    public static Boolean isSameDay(Date d1, Date d2) {
+        if ((d1 == null) || (d2 == null)) {
+            return false;
+        }
+        final Date d1Arr = untimed(d1);
+        final Date d2Arr = untimed(d2);
+        return (d1Arr.equals(d2Arr));
+    }
+
+    private static Date untimed(Date date) {
+        final Calendar cal = new GregorianCalendar();
+        cal.setTime(date);
+        cal.set(Calendar.HOUR_OF_DAY, 0);
+
+        return cal.getTime();
+    }
+
+
+
+}

--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -87,6 +87,7 @@
     "calendar.event.share": "Share",
     "calendar.share.recurrence.only.first": "Only the first recurrence of this event will be shared.",
     "calendar.event.save.error": "Error when saving the event.",
+    "calendar.event.length.error": "Your event cannot be longer than your recurrence.",
     "calendar.display.mode": "Display mode",
     "calendar.calendar.view": "Calendar",
     "calendar.list.view": "List",
@@ -99,7 +100,9 @@
     "calendar.event.recurrence.edition": "These changes will impact",
     "calendar.error.date.saving": "Saving issue : data is not valid",
     "calendar.error.time": "End time must be after start time.",
+    "calendar.error.date": "End date must be after or equal to start date.",
     "calendar.event.date": "Date: ",
     "calendar.event.time.from": "From ",
-    "calendar.event.time.tolc": "to "
+    "calendar.event.time.tolc": "to ",
+    "calendar.event.get.error": "Event cannot be retrieved"
 }

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -118,6 +118,7 @@
     "calendar.recurrence.daymap.sun":"Di",
     "calendar.error.date.saving": "Problème d'enregistrement : une donnée n'est pas valide",
     "calendar.error.time": "L'heure de fin doit être supérieure à l'heure de début.",
+    "calendar.error.date": "La date de fin doit être supérieure ou égale à la date de début.",
     "calendar.delete.error": "Une erreur est survenue lors de la supression du calendrier",
     "calendar.navigation.guard": "Les modifications que vous avez apportées ne seront peut-être pas enregistrées. Souhaitez vous quitter cette page?",
     "calendar.event.not.all.calendar.rights": "Vous n'avez pas les droits de modification sur cet évènement.",
@@ -133,6 +134,7 @@
     "calendar.event.share": "Partager",
     "calendar.share.recurrence.only.first": "Seule la première récurrence de cet évènement sera partagée.",
     "calendar.event.save.error": "Problème d'enregistrement de l'évènement.",
+    "calendar.event.length.error": "Votre évènement ne peut pas durer plus longtemps que votre récurrence",
     "calendar.display.mode": "Mode d'affichage",
     "calendar.calendar.view": "Calendaire",
     "calendar.list.view": "Liste",
@@ -145,5 +147,6 @@
     "calendar.event.recurrence.edition": "Vous souhaitez modifier",
     "calendar.event.date": "Date : ",
     "calendar.event.time.from": "De ",
-    "calendar.event.time.tolc": "à "
+    "calendar.event.time.tolc": "à ",
+    "calendar.event.get.error": "Erreur de récupération de l'évènement"
 }

--- a/src/main/resources/public/template/edit-event.html
+++ b/src/main/resources/public/template/edit-event.html
@@ -76,13 +76,23 @@
                         <div class="content">
 
                             <div class="row">
-                                <div class="six cell">
+                                <!--event start date-->
+                                <div class="three cell">
                                     <label class="twelve cell form-label">
                                         <i18n>calendar.event.start.date</i18n>
                                     </label>
                                     <date-picker ng-model="calendarEvent.startMoment"
-                                                 ng-change="changeStartMoment()"></date-picker>
+                                                 ng-change="changeStartMoment()" class="nine cell"></date-picker>
                                 </div>
+                                <!--event end date-->
+                                <div class="three cell">
+                                    <label class="twelve cell form-label">
+                                        <i18n>calendar.event.end.date</i18n>
+                                    </label>
+                                    <date-picker ng-model="calendarEvent.endMoment"
+                                                 ng-change="changeEndMoment()" class="nine cell"></date-picker>
+                                </div>
+                                <!--event start hour-->
                                 <div class="three cell" ng-if="!calendarEvent.allday">
                                     <label class="twelve cell form-label">
                                         <i18n>calendar.event.start.time</i18n>
@@ -94,6 +104,7 @@
                                            step="60" start-moment="calendarEvent.startMoment"
                                            end-moment="calendarEvent.endMoment" required/>
                                 </div>
+                                <!--event end hour-->
                                 <div class="three cell" ng-if="!calendarEvent.allday">
                                     <label class="twelve cell form-label">
                                         <i18n>calendar.event.end.time</i18n>
@@ -118,6 +129,9 @@
 
                             <div class="top-spacing-twice warning form-element" ng-if="!isTimeValid()">
                                 <i18n>calendar.error.time</i18n>
+                            </div>
+                            <div class="top-spacing-twice warning form-element" ng-if="!isDateValid()">
+                                <i18n>calendar.error.date</i18n>
                             </div>
                         </div>
                     </div>
@@ -146,7 +160,9 @@
                                         </label>
                                         <select ng-model="calendarEvent.recurrence.type"
                                                 ng-change="changedRecurrenceType()">
-                                            <option value="every_day">[[lang.translate("calendar.recurrence.every.day")]]
+                                            <!--events that last more than one day cannot have a daily recurrence-->
+                                            <option value="every_day" ng-if="isOneDayEvent()">
+                                                [[lang.translate("calendar.recurrence.every.day")]]
                                             </option>
                                             <option value="every_week">
                                                 [[lang.translate("calendar.recurrence.every.week")]]
@@ -154,7 +170,7 @@
                                         </select>
                                     </div>
 
-                                    <div class="row" ng-if="calendarEvent.recurrence.type === 'every_day'">
+                                    <div class="row" ng-if="calendarEvent.recurrence.type === 'every_day' && isOneDayEvent()">
                                         <i18n>calendar.recurrence.every</i18n>
                                         <select ng-model="calendarEvent.recurrence.every"
                                                 ng-options="n for n in _.range(1, periods.every_day_max)"
@@ -173,10 +189,10 @@
                                             </select>
                                             <i18n>calendar.recurrence.weeks</i18n>
                                         </div>
-                                        <div class="row">
+                                        <div class="row" ng-if="isOneDayEvent()">
                                             <i18n>calendar.recurrence.repeat.on</i18n>
                                         </div>
-                                        <div class="row">
+                                        <div class="row" ng-if="isOneDayEvent()">
                                             <label class="cell right-spacing"
                                                    ng-repeat="(key, value) in calendarEvent.recurrence.week_days">
                                                 <input type="checkbox" value="[[key]]"
@@ -291,6 +307,9 @@
                                            ng-checked="!calendarEvent.noMoreRecurrent"/>
                                     <i18n>calendar.event.remove.others.from.recurrence</i18n>
                                 </div>
+                            </div>
+                            <div class="top-spacing-twice warning form-element" ng-if="!areRecurrenceAndEventLengthsCompatible()">
+                                <i18n>calendar.event.length.error</i18n>
                             </div>
                         </div>
                     </div>

--- a/src/main/resources/public/ts/core/const/date-format.ts
+++ b/src/main/resources/public/ts/core/const/date-format.ts
@@ -1,5 +1,6 @@
 export const FORMAT = {
     formattedDate: 'YYYY-MM-DD',
+    formattedISODate: 'YYYY-MM-DDTHH:mm:ss.SSSSZ',
     formattedTime: 'HH:mm:ss',
     formattedDateTime: 'YYYY-MM-DD HH:mm:ss',
     displayDate: 'YYYY/MM/DD',

--- a/src/main/resources/public/ts/model/constantes/actions.const.ts
+++ b/src/main/resources/public/ts/model/constantes/actions.const.ts
@@ -2,7 +2,8 @@ export const ACTIONS = {
     create: 'create',
     save: 'save',
     delete: 'delete',
-    share: 'share'
+    share: 'share',
+    update: 'update'
 }
 
 export type ActionButtonType = "save" | "share" | "delete";

--- a/src/main/resources/public/ts/utils/multiDaysEventsUtils.ts
+++ b/src/main/resources/public/ts/utils/multiDaysEventsUtils.ts
@@ -1,0 +1,42 @@
+import { moment } from 'entcore';
+import { Moment } from 'moment';
+import {CalendarEvent, CalendarEvents} from '../model/CalendarEvent';
+import {timeConfig} from "../model/constantes";
+import {FORMAT} from "../core/const/date-format";
+
+export class multiDaysEventsUtils {
+
+    /**
+     * Takes a multiple day event as a parameter and separates it into one-day events
+     * @param multiDayEvent a multiple day event
+     * @return dividedEvent array of events created from the original event
+     */
+    static createMultiDayEventParts = (multiDayEvent : CalendarEvent) : CalendarEvent[] => {
+        let dividedEvent : CalendarEvent[] = [];
+        let temporaryEventDate : Moment = moment(multiDayEvent.startMoment);
+
+        while (moment(multiDayEvent.endMoment).isSameOrAfter(temporaryEventDate, 'day')){
+            let temporaryEvent : CalendarEvent = new CalendarEvent(multiDayEvent);
+            //all days except the first day of the event
+            if (!multiDaysEventsUtils.isEventMultiDays(moment(multiDayEvent.startMoment), temporaryEventDate)){
+                temporaryEvent.startMoment = moment(temporaryEventDate).hours(timeConfig.start_hour).minutes(0).second(0).millisecond(0)
+                    .utc().format(FORMAT.formattedISODate);
+            }
+            //all days except the last day of the event
+            if (!multiDaysEventsUtils.isEventMultiDays(moment(multiDayEvent.endMoment), temporaryEventDate)){
+                temporaryEvent.endMoment = moment(temporaryEventDate).hours(timeConfig.end_hour).minutes(0).second(0).millisecond(0)
+                    .utc().format(FORMAT.formattedISODate);
+            }
+            temporaryEvent.isMultiDayPart = true;
+            dividedEvent.push(temporaryEvent);
+            temporaryEventDate = moment(temporaryEventDate).add(1, 'day').valueOf();
+        }
+        return dividedEvent;
+    };
+
+    static isEventMultiDays = (startDate : Moment, endDate : Moment) : boolean => {
+        return startDate.isSame(endDate, 'day');
+    };
+
+
+}


### PR DESCRIPTION
Les évènements peuvent durer plusieurs jours:
- ils sont affichés comme étant des créneaux de 7h à 20h sur le calendrier (vue calendaire) :  création de sous-évènements dans le front (contenant un champ isMultiDayPart = true)
- restauration des évènements entiers pour la vue liste
- création d'un fichier d'utils pour séparer un évènement en sous évènements
- un évènement récurrent ne peut pas avoir une longueur supérieure à celle de la récurrence
- un évènement sur plusieurs jours ne peut avoir qu'une récurrence hebdomadaire
- pour la récurrence, si la date de fin de récurrence se trouve entre le début et la fin de l'évènement sur plusieurs jours, il sera quand même enregistré