### PR TITLE
fix(calendar) : #MC-51 select default calendar automatically when loading page

### DIFF
--- a/src/main/resources/public/ts/controllers/controller.ts
+++ b/src/main/resources/public/ts/controllers/controller.ts
@@ -102,6 +102,12 @@ export const calendarController =  ng.controller('CalendarController',
                     $scope.calendars.preference.sync()
                 ]);
                 $scope.loadSelectedCalendars();
+
+                //ensure that default calendar is selected
+                let defaultCalendar : Calendar = $scope.calendars.all.find(cal => cal.is_default == true);
+                defaultCalendar.selected = false;
+                $scope.openOrCloseCalendar(defaultCalendar, true);
+
                 $scope.firstOwnedEvent();
                 $scope.initEventDates(moment().utc().second(0).millisecond(0), moment().utc().second(0).millisecond(0).add(1, 'hours'));
                 setCalendarLang();


### PR DESCRIPTION
Problem : when accessing the calendar page for the first time, no calendar is selected and the calendar timetable therefore does not appear.
Solution : Selecting the default calendar specifically when loading the page