### PR TITLE
fix(performance): #MC-69 lazy loading to fetch events

### DIFF
--- a/src/main/java/net/atos/entng/calendar/controllers/EventController.java
+++ b/src/main/java/net/atos/entng/calendar/controllers/EventController.java
@@ -134,7 +134,7 @@ public class EventController extends MongoDbControllerHelper {
                         shareResource(request, "calendar.share", false, params, "title");
                         eventHelper.addEventToUsersCalendar(id, body, user, host, lang);
                     }
-        }));
+                }));
     }
 
     @Get("/:id/ical")
@@ -174,17 +174,18 @@ public class EventController extends MongoDbControllerHelper {
 
     /**
      * Get nb events from a list of calendars (widget)
+     *
      * @param request request
      */
     @Get("/events/widget")
     @SecuredAction(value = "", type = ActionType.RESOURCE)
     @ResourceFilter(CustomWidgetFilter.class)
-    public void getWidgetEvents (HttpServerRequest request) {
+    public void getWidgetEvents(HttpServerRequest request) {
         List<String> calendarIds = request.params().getAll("calendarId");
         int nbLimit;
         try {
             nbLimit = Integer.parseInt(request.params().get("nb"));
-        } catch(NumberFormatException e) {
+        } catch (NumberFormatException e) {
             nbLimit = 5;
         }
         eventHelper.listWidgetEvents(request, calendarIds.toArray(new String[0]), nbLimit);

--- a/src/main/java/net/atos/entng/calendar/core/constants/Field.java
+++ b/src/main/java/net/atos/entng/calendar/core/constants/Field.java
@@ -17,13 +17,20 @@ public class Field {
     public static final String calendarEvent = "calendarEvent";
 
     // event start moment
-    public static final String startMoment = "startMoment";
+    public static final String STARTMOMENT = "startMoment";
     // event end moment
-    public static final String endMoment = "endMoment";
+    public static final String ENDMOMENT = "endMoment";
     //calendars
-    public static final String calendars = "calendars";
+    public static final String CALENDARS = "calendars";
     //Owner
-    public static final String owner = "owner";
+    public static final String OWNER = "owner";
+    //Calendar id
+    public static final String _ID = "_id";
+
+    // start date from range
+    public static final String STARTDATE = "startDate";
+    // end date from range
+    public static final String ENDDATE = "endDate";
 
     //Recurrence
     // event is recurrent or not

--- a/src/main/java/net/atos/entng/calendar/helpers/EventHelper.java
+++ b/src/main/java/net/atos/entng/calendar/helpers/EventHelper.java
@@ -24,7 +24,6 @@ import static org.entcore.common.http.response.DefaultResponseHandler.arrayRespo
 import static org.entcore.common.http.response.DefaultResponseHandler.defaultResponseHandler;
 import static org.entcore.common.http.response.DefaultResponseHandler.notEmptyResponseHandler;
 import static org.entcore.common.mongodb.MongoDbResult.validResultHandler;
-import static org.entcore.common.mongodb.MongoDbResult.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -104,10 +103,11 @@ public class EventHelper extends MongoDbControllerHelper {
             @Override
             public void handle(final UserInfos user) {
                 String calendarId = request.params().get(CALENDAR_ID_PARAMETER);
-                eventService.list(calendarId, user, arrayResponseHandler(request));
+                String startDate = request.params().get(Field.STARTDATE);
+                String endDate = request.params().get(Field.ENDDATE);
+                eventService.list(calendarId, user, startDate, endDate, arrayResponseHandler(request));
             }
         });
-
     }
 
     @Override
@@ -130,7 +130,7 @@ public class EventHelper extends MongoDbControllerHelper {
                                             message.put("eventId", eventId.getString("_id"));
                                             message.put("start_date", (String) null);
                                             message.put("end_date", (String) null);
-                                            message.put("sendNotif", object.containsKey("sendNotif")? object.getBoolean("sendNotif"):null);
+                                            message.put("sendNotif", object.containsKey("sendNotif") ? object.getBoolean("sendNotif") : null);
                                             notifyEventCreatedOrUpdated(request, user, message, true);
                                             renderJson(request, event.right().getValue(), 200);
                                             eventHelper.onCreateResource(request, RESOURCE_NAME);
@@ -139,7 +139,7 @@ public class EventHelper extends MongoDbControllerHelper {
                                         }
                                     }
                                 });
-                            }else{
+                            } else {
                                 log.error(String.format("[Calendar@EventHelper::create] " + "Submitted event is not valid"),
                                         I18n.getInstance().translate("calendar.error.date.saving", getHost(request), I18n.acceptLanguage(request)));
                                 Renders.unauthorized(request);
@@ -173,7 +173,7 @@ public class EventHelper extends MongoDbControllerHelper {
                                         message.put("eventId", eventId);
                                         message.put("start_date", (String) null);
                                         message.put("end_date", (String) null);
-                                        message.put("sendNotif", object.containsKey("sendNotif")? object.getBoolean("sendNotif"):null);
+                                        message.put("sendNotif", object.containsKey("sendNotif") ? object.getBoolean("sendNotif") : null);
                                         notifyEventCreatedOrUpdated(request, user, message, false);
                                         renderJson(request, event.right().getValue(), 200);
                                     } else if (event.isLeft()) {
@@ -294,9 +294,9 @@ public class EventHelper extends MongoDbControllerHelper {
 
                     Boolean restrictedEvent = (calendarEvent.containsKey("shared") || Boolean.TRUE.equals(calendarEvent.getBoolean("is_default")))
                             && Boolean.FALSE.equals(calendarEvent.getJsonArray("shared").isEmpty());
-                    if(!calendar.isEmpty()){
-                        for(Object id : calendar){
-                            if(message.getBoolean("sendNotif") == null || Boolean.FALSE.equals(isCreated)) {
+                    if (!calendar.isEmpty()) {
+                        for (Object id : calendar) {
+                            if (message.getBoolean("sendNotif") == null || Boolean.FALSE.equals(isCreated)) {
                                 notifyUsersSharing(request, user, id.toString(), calendarEvent, isCreated, restrictedEvent);
                             }
                         }
@@ -310,11 +310,10 @@ public class EventHelper extends MongoDbControllerHelper {
 
 
     /**
-     *
-     * @param request HttpServerRequest request from the server
-     * @param user User Object user that created/edited the event
-     * @param calendarId JsonObject calendar in which the event appears
-     * @param calendarEvent JsonObject event that is created/edited
+     * @param request         HttpServerRequest request from the server
+     * @param user            User Object user that created/edited the event
+     * @param calendarId      JsonObject calendar in which the event appears
+     * @param calendarEvent   JsonObject event that is created/edited
      * @param restrictedEvent Boolean that tells if event is restricted or not
      */
     public void notifyUsersSharing(final HttpServerRequest request, final UserInfos user, final String calendarId,
@@ -395,7 +394,7 @@ public class EventHelper extends MongoDbControllerHelper {
                             if ("ok".equals(res.body().getString("status"))) {
                                 JsonArray listOfUsers = res.body().getJsonArray("result");
                                 // param => rajouter la logique
-                                if (restrictedEvent){
+                                if (restrictedEvent) {
                                     restrictListOfUsers(listOfUsers, user, calendar, calendarEvent, handler);
                                 } else {
                                     proceedOnUserList(listOfUsers, calendar, handler);
@@ -409,7 +408,7 @@ public class EventHelper extends MongoDbControllerHelper {
                         handler.handle(null);
                     }
                 } // end if shared != null
-                if(shared == null && Boolean.TRUE.equals(calendar.getBoolean("is_default")) && restrictedEvent){
+                if (shared == null && Boolean.TRUE.equals(calendar.getBoolean("is_default")) && restrictedEvent) {
                     JsonArray defaultCalendarOwner = new JsonArray().add(new JsonObject().put("id", calendar.getJsonObject("owner", new JsonObject())
                             .getString("userId", null)));
                     proceedOnUserList(defaultCalendarOwner, calendar, handler);
@@ -423,20 +422,21 @@ public class EventHelper extends MongoDbControllerHelper {
      * The event start date should be before the event end date
      * If the event lasts more than one day and is recurrent, it should last less than the recurrence length
      * and the recurrence must be at least weekly
-     * @param object JsonObject, the event to save
+     *
+     * @param object  JsonObject, the event to save
      * @param request HttpServerRequest, the saving request
      * @return true if the event meets the requirements mentionned before
      */
-    private boolean isEventValid (JsonObject object, HttpServerRequest request) {
-        Date startDate = DateUtils.parseDate(object.getString(Field.startMoment), DateUtils.DATE_FORMAT_UTC);
-        Date endDate = DateUtils.parseDate(object.getString(Field.endMoment), DateUtils.DATE_FORMAT_UTC);
+    private boolean isEventValid(JsonObject object, HttpServerRequest request) {
+        Date startDate = DateUtils.parseDate(object.getString(Field.STARTMOMENT), DateUtils.DATE_FORMAT_UTC);
+        Date endDate = DateUtils.parseDate(object.getString(Field.ENDMOMENT), DateUtils.DATE_FORMAT_UTC);
 
         boolean areDatesValid = DateUtils.isStrictlyBefore(startDate, endDate);
         boolean isOneDayEvent = DateUtils.isSameDay(startDate, endDate);
         boolean isNotRecurrentEvent = Boolean.FALSE.equals(object.getBoolean(Field.isRecurrent));
 
         long dayInMilliseconds = 1000 * 60 * 60 * 24;
-        int eventDayLength = (int) ((endDate.getTime() - startDate.getTime())/dayInMilliseconds);
+        int eventDayLength = (int) ((endDate.getTime() - startDate.getTime()) / dayInMilliseconds);
 
         boolean isWeeklyRecurrenceValid = object.getValue(Field.recurrence) instanceof JsonObject
                 && "every_week".equals(object.getJsonObject(Field.recurrence).getValue(Field.type))
@@ -449,11 +449,11 @@ public class EventHelper extends MongoDbControllerHelper {
      * Prepare notification user list so that it contains only the people the event is shared with and that have access to the calendar,
      * and the calendar owner and the event owner if they are different from the person editing
      *
-     * @param listOfUsers JsonArray of the ids of the users with access to the calendar
-     * @param user User Object, the user that edited the event
-     * @param calendar JsonObject, the targeted calendar
+     * @param listOfUsers   JsonArray of the ids of the users with access to the calendar
+     * @param user          User Object, the user that edited the event
+     * @param calendar      JsonObject, the targeted calendar
      * @param calendarEvent JsonObject the edited event
-     * @param handler Handler used by notifyUsersSharing()
+     * @param handler       Handler used by notifyUsersSharing()
      */
     @SuppressWarnings("unchecked")
     private void restrictListOfUsers(JsonArray listOfUsers, final UserInfos user, JsonObject calendar, JsonObject calendarEvent,
@@ -464,43 +464,43 @@ public class EventHelper extends MongoDbControllerHelper {
 
         //get all userIds from groups for event
         userService.fetchUser(calendarEventShared, user, false)
-            .onSuccess(e -> {
-                List<String> calendarEventShareIds = e.stream().map(User::id).collect(Collectors.toList());
+                .onSuccess(e -> {
+                    List<String> calendarEventShareIds = e.stream().map(User::id).collect(Collectors.toList());
 
-                //keep ids from shareIds that appear in calendarEventShareIds
-                List<String> userIds = ((List<JsonObject>) listOfUsers.getList())
-                        .stream()
-                        .map((currentUser) -> currentUser.getString("id"))
-                        .collect(Collectors.toList());
-                userIds.retainAll(calendarEventShareIds);
+                    //keep ids from shareIds that appear in calendarEventShareIds
+                    List<String> userIds = ((List<JsonObject>) listOfUsers.getList())
+                            .stream()
+                            .map((currentUser) -> currentUser.getString("id"))
+                            .collect(Collectors.toList());
+                    userIds.retainAll(calendarEventShareIds);
 
-                if (!user.getUserId().equals(calendar.getJsonObject("owner").getString("userId"))) {
-                    userIds.add(calendar.getJsonObject("owner").getString("userId"));
-                }
-                if (!user.getUserId().equals(calendarEvent.getJsonObject("owner").getString("userId"))){
-                    userIds.add(calendarEvent.getJsonObject("owner").getString("userId"));
-                }
+                    if (!user.getUserId().equals(calendar.getJsonObject("owner").getString("userId"))) {
+                        userIds.add(calendar.getJsonObject("owner").getString("userId"));
+                    }
+                    if (!user.getUserId().equals(calendarEvent.getJsonObject("owner").getString("userId"))) {
+                        userIds.add(calendarEvent.getJsonObject("owner").getString("userId"));
+                    }
 
-                JsonArray finalUserIds = new JsonArray(userIds.stream()
-                        .map((currentUser) -> new JsonObject().put("id", currentUser))
-                        .collect(Collectors.toList()));
+                    JsonArray finalUserIds = new JsonArray(userIds.stream()
+                            .map((currentUser) -> new JsonObject().put("id", currentUser))
+                            .collect(Collectors.toList()));
 
-                proceedOnUserList(finalUserIds, calendar, handler);
-            })
-            .onFailure( err -> {
-                String message = String.format("[Calendar@%s::restrictListOfUsers] An error has occured" +
-                                " during fetching userIds, see previous logs: %s",
-                        this.getClass().getSimpleName(), err.getMessage());
-                log.error(message, err.getMessage());
-            });
+                    proceedOnUserList(finalUserIds, calendar, handler);
+                })
+                .onFailure(err -> {
+                    String message = String.format("[Calendar@%s::restrictListOfUsers] An error has occured" +
+                                    " during fetching userIds, see previous logs: %s",
+                            this.getClass().getSimpleName(), err.getMessage());
+                    log.error(message, err.getMessage());
+                });
     }
 
     /**
      * Prepare information to notify users
      *
      * @param listOfUsers JsonArray of the users (ids) that should be notified
-     * @param calendar JsonObject of the current calendar
-     * @param handler Handler used by notifyUsersSharing()
+     * @param calendar    JsonObject of the current calendar
+     * @param handler     Handler used by notifyUsersSharing()
      */
     private void proceedOnUserList(JsonArray listOfUsers, JsonObject calendar, Handler<Map<String, Object>> handler) {
         List<String> recipients = new ArrayList<>();
@@ -517,16 +517,17 @@ public class EventHelper extends MongoDbControllerHelper {
         handler.handle(t);
     }
 
-    private List<String> getSharedIds(JsonArray shared){
+    private List<String> getSharedIds(JsonArray shared) {
         return getSharedIds(shared, null);
     }
+
     private List<String> getSharedIds(JsonArray shared, String filterRights) {
         List<String> shareIds = new ArrayList<>();
         for (Object o : shared) {
             if (!(o instanceof JsonObject)) continue;
             JsonObject userShared = (JsonObject) o;
 
-            if(filterRights != null && !userShared.getBoolean(filterRights, false))
+            if (filterRights != null && !userShared.getBoolean(filterRights, false))
                 continue;
 
             String userOrGroupId = userShared.getString("groupId",
@@ -586,11 +587,11 @@ public class EventHelper extends MongoDbControllerHelper {
     /**
      * method launched in background to add extra calendar into Calendar Event
      *
-     * @param eventId       calendar event identifier {@link String}
-     * @param shared        body's shared sent {@link JsonObject}
-     * @param user          user info {@link UserInfos}
-     * @param host          host param {@link String}
-     * @param lang          lang param {@link String}
+     * @param eventId calendar event identifier {@link String}
+     * @param shared  body's shared sent {@link JsonObject}
+     * @param user    user info {@link UserInfos}
+     * @param host    host param {@link String}
+     * @param lang    lang param {@link String}
      */
     public void addEventToUsersCalendar(String eventId, JsonObject shared, UserInfos user, String host, String lang) {
         List<String> sharedIds = new ArrayList<>(shared.getJsonObject("users").fieldNames());
@@ -605,7 +606,7 @@ public class EventHelper extends MongoDbControllerHelper {
                         shareIdsFromCalendar, host, lang, user))
                 .onFailure(err -> {
                     String message = String.format("[Calendar@%s::addEventToUsersCalendar] An error has occured" +
-                            " during fetching userIds or calendar event, see previous logs: %s",
+                                    " during fetching userIds or calendar event, see previous logs: %s",
                             this.getClass().getSimpleName(), err.getMessage());
                     log.error(message, err.getMessage());
                 });
@@ -616,9 +617,8 @@ public class EventHelper extends MongoDbControllerHelper {
      * {'calendarEvent': {@link JsonObject}, 'calendars': {@link JsonArray}}
      * will fetch all userIds and groupId to fetch all User
      *
-     * @param user                      user info {@link UserInfos}
-     * @param calendarsEventFuture      calendars and event data as {@link JsonObject}
-     *
+     * @param user                 user info {@link UserInfos}
+     * @param calendarsEventFuture calendars and event data as {@link JsonObject}
      * @return {@link Future} of {@link List<User>} containing list of User fetched
      */
     private Future<List<User>> retrieveAllUsersFromCalendarsEvent(UserInfos user, Future<JsonObject> calendarsEventFuture) {
@@ -631,17 +631,16 @@ public class EventHelper extends MongoDbControllerHelper {
      * {'calendarEvent': {@link JsonObject}, 'calendars': {@link JsonArray}}
      * will fetch all userIds and groupId to fetch all User
      *
-     * @param user                      user info {@link UserInfos}
+     * @param user                user info {@link UserInfos}
      * @param calendarsEvent      calendars and event data as {@link JsonObject}
-     * @param keepUserFromSession       if the user from the session should be fetched {@link boolean}
-     * @param keepCalendarsOwners       if the calendarOwners should be fetched {@link boolean}
-     *
+     * @param keepUserFromSession if the user from the session should be fetched {@link boolean}
+     * @param keepCalendarsOwners if the calendarOwners should be fetched {@link boolean}
      * @return {@link Future} of {@link List<User>} containing list of User fetched
      */
     @SuppressWarnings("unchecked")
     private Future<List<User>> retrieveAllUsersFromCalendarsEvent(UserInfos user, JsonObject calendarsEvent,
-      boolean keepUserFromSession, boolean keepCalendarsOwners) {
-        List<String> shareIdsFromAllCalendar = ((List<JsonObject>) calendarsEvent.getJsonArray(Field.calendars, new JsonArray()).getList()).stream()
+                                                                  boolean keepUserFromSession, boolean keepCalendarsOwners) {
+        List<String> shareIdsFromAllCalendar = ((List<JsonObject>) calendarsEvent.getJsonArray(Field.CALENDARS, new JsonArray()).getList()).stream()
                 .flatMap(calendar -> ((List<JsonObject>) calendar.getJsonArray(Field.shared, new JsonArray()).getList())
                         .stream()
                         .map(s -> s.getString(Field.userId, s.getString(Field.groupId, null)))
@@ -652,8 +651,8 @@ public class EventHelper extends MongoDbControllerHelper {
 
         if (keepCalendarsOwners) {
             //add calendar owners to list
-            List<String> calendarsOwners = ((List<JsonObject>) calendarsEvent.getJsonArray(Field.calendars, new JsonArray()).getList()).stream()
-                    .map(c -> c.getJsonObject(Field.owner, null).getString(Field.userId, null))
+            List<String> calendarsOwners = ((List<JsonObject>) calendarsEvent.getJsonArray(Field.CALENDARS, new JsonArray()).getList()).stream()
+                    .map(c -> c.getJsonObject(Field.OWNER, null).getString(Field.userId, null))
                     .filter(Objects::nonNull)
                     .distinct()
                     .collect(Collectors.toList());
@@ -671,14 +670,13 @@ public class EventHelper extends MongoDbControllerHelper {
      * differences between users fetched from payload and calendars in order to get users that do not belong to both list
      * Afterwards, we will proceed on each user in order to get their default calendar identifier and add to our original event
      *
-     * @param eventId                   calendar event identifer {@link String}
-     * @param usersFromPayload          list of user identifier fetched from payload shared body sent info {@link List<User>}
-     * @param calendarsEventFuture      calendarEvent and calendars as {@link JsonObject}
-     * @param usersFromSharedCalendars  list of shared containing user and group identifier from all calendars {@link List<User>}
-     * @param host                      host param {@link String}
-     * @param lang                      lang param {@link String}
-     * @param userInfos                 user session infos {@link Object}
-     *
+     * @param eventId                  calendar event identifer {@link String}
+     * @param usersFromPayload         list of user identifier fetched from payload shared body sent info {@link List<User>}
+     * @param calendarsEventFuture     calendarEvent and calendars as {@link JsonObject}
+     * @param usersFromSharedCalendars list of shared containing user and group identifier from all calendars {@link List<User>}
+     * @param host                     host param {@link String}
+     * @param lang                     lang param {@link String}
+     * @param userInfos                user session infos {@link Object}
      * @return {@link Future} of {@link Void}
      */
     private Future<Void> proceedOnUsersFetched(String eventId, List<User> usersFromPayload, JsonObject calendarsEventFuture,
@@ -693,7 +691,7 @@ public class EventHelper extends MongoDbControllerHelper {
         List<String> originalCalendars = determineOriginalCalendars(calendarsEventFuture, userInfos);
 
         List<Future<String>> futures = new ArrayList<>();
-        for (User userNotAccess: usersFromPayload) {
+        for (User userNotAccess : usersFromPayload) {
             futures.add(fetchDefaultCalendar(userNotAccess, host, lang));
         }
 
@@ -717,9 +715,8 @@ public class EventHelper extends MongoDbControllerHelper {
      * Determine among these calendars who were the originals when the calendar event was created to keep persisting
      * its identifier(s)
      *
-     * @param calendarEvent      calendarEvent and calendars as {@link JsonObject}
-     * @param userInfos                 user session infos {@link Object}
-     *
+     * @param calendarEvent calendarEvent and calendars as {@link JsonObject}
+     * @param userInfos     user session infos {@link Object}
      * @return {@link Future} of {@link List<String>} the "original(s)" calendar(s)
      */
     @SuppressWarnings("unchecked")
@@ -747,10 +744,9 @@ public class EventHelper extends MongoDbControllerHelper {
     /**
      * retrieve default calendar identifier
      *
-     * @param user  user data {@link User}
-     * @param host  host param {@link String}
-     * @param lang  lang param {@link String}
-     *
+     * @param user user data {@link User}
+     * @param host host param {@link String}
+     * @param lang lang param {@link String}
      * @return {@link Future} of {@link String} default calendar identifier
      */
     private Future<String> fetchDefaultCalendar(User user, String host, String lang) {
@@ -776,8 +772,7 @@ public class EventHelper extends MongoDbControllerHelper {
     /**
      * fetch calendarEvent and all calendars linked to calendarEvent
      *
-     * @param eventId       calendar event identifier {@link String}
-     *
+     * @param eventId calendar event identifier {@link String}
      * @return {@link Future} of {@link JsonObject} containing JsonObject of
      * {'calendarEvent': {@link JsonObject}, 'calendars': {@link JsonArray}}
      */
@@ -807,8 +802,7 @@ public class EventHelper extends MongoDbControllerHelper {
     /**
      * fetch calendarEvent
      *
-     * @param eventId       calendar event identifier {@link String}
-     *
+     * @param eventId calendar event identifier {@link String}
      * @return {@link Future} of {@link JsonObject} containing calendarEvent
      */
     private Future<JsonObject> fetchCalendarEventById(String eventId) {
@@ -830,9 +824,9 @@ public class EventHelper extends MongoDbControllerHelper {
 
     /**
      * Check if the user has access to the event
-     * @param eventId the id of the event {@link String}
-     * @param user the user currently logged in {@link UserInfos}
      *
+     * @param eventId the id of the event {@link String}
+     * @param user    the user currently logged in {@link UserInfos}
      * @return {@link Boolean} being true if the user has access to the event, false instead
      */
     public Future<Boolean> hasAccessToEvent(String eventId, UserInfos user) {
@@ -847,8 +841,8 @@ public class EventHelper extends MongoDbControllerHelper {
                 })
                 .onSuccess(eventInfos -> {
                     //check if user is event owner
-                    String calendarEventOwner = eventInfos.getJsonObject(Field.calendarEvent).getJsonObject(Field.owner).getString(Field.userId);
-                    if(calendarEventOwner.equals(user.getUserId())) {
+                    String calendarEventOwner = eventInfos.getJsonObject(Field.calendarEvent).getJsonObject(Field.OWNER).getString(Field.userId);
+                    if (calendarEventOwner.equals(user.getUserId())) {
                         promise.complete(true); //user is event owner
                     } else {
                         //get all users with access to the calendars of this event
@@ -860,13 +854,13 @@ public class EventHelper extends MongoDbControllerHelper {
                                     promise.fail(fail.getMessage());
                                 })
                                 .onSuccess(usersWithAccessToEvent -> {
-                                        //find if user is among the users that can access the event
-                                        List<User> matchingUsers = usersWithAccessToEvent
-                                                .stream()
-                                                .filter(currentUser -> currentUser.id().equals(user.getUserId()))
-                                                .collect(Collectors.toList()); //check if users match user session
+                                    //find if user is among the users that can access the event
+                                    List<User> matchingUsers = usersWithAccessToEvent
+                                            .stream()
+                                            .filter(currentUser -> currentUser.id().equals(user.getUserId()))
+                                            .collect(Collectors.toList()); //check if users match user session
 
-                                        promise.complete(!matchingUsers.isEmpty());
+                                    promise.complete(!matchingUsers.isEmpty());
                                 });
                     }
                 });
@@ -876,15 +870,15 @@ public class EventHelper extends MongoDbControllerHelper {
 
     /**
      * Get file from documents collection
-     * @param hasAccess whether the user has access to the event or not
-     * @param attachmentId the id of the file {@link String}
      *
+     * @param hasAccess    whether the user has access to the event or not
+     * @param attachmentId the id of the file {@link String}
      * @return {@link Future} of {@link JsonObject} being true if the user is owner of the file, false instead
      */
     public Future<JsonObject> getAttachment(Boolean hasAccess, String attachmentId) {
         Promise<JsonObject> promise = Promise.promise();
 
-        if(Boolean.FALSE.equals(hasAccess)){
+        if (Boolean.FALSE.equals(hasAccess)) {
             promise.fail(String.format("[Calendar@EventHelper::getAttachment] User does not have access to file"));
         }
 
@@ -892,7 +886,7 @@ public class EventHelper extends MongoDbControllerHelper {
         QueryBuilder query = QueryBuilder.start(Field.id).is(attachmentId);
 
         mongo.findOne(Calendar.DOCUMENTS_COLLECTION, MongoQueryBuilder.build(query), validResultHandler(result -> {
-            if(result.isLeft() || result.right().getValue().size() == 0 || !(result.right().getValue() instanceof JsonObject) ) {
+            if (result.isLeft() || result.right().getValue().size() == 0 || !(result.right().getValue() instanceof JsonObject)) {
                 String message = String.format("[Calendar@%s::getAttachment]:  an error has occurred while finding file: %s",
                         this.getClass().getSimpleName(), result.left().getValue());
                 log.error(message);

--- a/src/main/java/net/atos/entng/calendar/services/EventServiceMongo.java
+++ b/src/main/java/net/atos/entng/calendar/services/EventServiceMongo.java
@@ -32,6 +32,8 @@ public interface EventServiceMongo {
 
     void list(String calendarId, UserInfos user, Handler<Either<String, JsonArray>> handler);
 
+    void list(String calendarId, UserInfos user,  String startDate, String endDate, Handler<Either<String, JsonArray>> handler);
+
     void create(String calendarId, JsonObject body, UserInfos user, Handler<Either<String, JsonObject>> handler);
 
     void retrieve(String calendarId, String eventId, UserInfos user, Handler<Either<String, JsonObject>> handler);

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -48,6 +48,7 @@
     "calendar.ics.file.import.report": "Rapport d'import de fichier ICS",
     "calendar.ics.file.to.import": "Sélectionner un fichier iCal",
     "calendar.notify.icsImportError": "Erreur d'importation du fichier ICS",
+    "calendar.notify.sync.calendars.error": "Erreur de synchronisation des calendriers",
     "calendar.recurrence": "Récurrence",
     "calendar.reccurent": "Récurrent",
     "calendar.recurrence.days": "jours",

--- a/src/main/resources/public/ts/controllers/controller.ts
+++ b/src/main/resources/public/ts/controllers/controller.ts
@@ -29,8 +29,9 @@ import {Moment} from "moment";
 import {FORMAT} from "../core/const/date-format";
 import {DAY_OF_WEEK} from "../core/enum/dayOfWeek.enum";
 import {attachmentService} from "../services/attachment.service";
+import {PERIODE_TYPE} from "../core/enum/period-type.enum";
 
-export const calendarController =  ng.controller('CalendarController',
+export const calendarController = ng.controller('CalendarController',
     ["$location",
         "$scope",
         "$timeout",
@@ -39,347 +40,379 @@ export const calendarController =  ng.controller('CalendarController',
         "model",
         "route",
         ($location, $scope, $timeout, $compile, $sanitize, model, route) => {
-        $scope._ = _;
-        $scope.lang = lang;
-        $scope.template = template;
-        $scope.display = {};
-        $scope.display.list = false;
-        $scope.display.calendar = false;
-        $scope.display.editEventRight = false;
-        $scope.model = model;
-        $scope.me = model.me;
-        $scope.calendarEvent = new CalendarEvent();
-        $scope.calendars = new Calendars();
-        $scope.display.importFileButtonDisabled = true;
-        $scope.calendarEvents= new CalendarEvents() ;
-        $scope.periods = periods;
-        $scope.newFile = {};
-        $scope.propertyName = 'startMoment';
-        $scope.reverse = true;
-        $scope.calendar = new Calendar();
-        $scope.display.selectAllCalendarEvents = false;
-        $scope.timeConfig =  timeConfig;
-        $scope.recurrence = recurrence;
-        $scope.reader = new FileReader();
-        $scope.jsonData = {ics: {}};
-        $scope.calendarEvents.filters.startMoment = moment().startOf('day');
-        $scope.calendarEvents.filters.endMoment = moment().add(2, 'months').startOf('day');
-        $scope.contentToWatch = "";
-        $scope.calendarCreationScreen = false;
-        $scope.calendarAsContribRight = new Array<Calendar>();
-        $scope.selectedCalendarInEvent = new Array<Calendar>();
-        $scope.rights = rights;
-        $scope.buttonAction = ACTIONS;
-        $scope.eventSidebar$ = new Subject<void>();
+            $scope._ = _;
+            $scope.lang = lang;
+            $scope.template = template;
+            $scope.display = {};
+            $scope.display.list = false;
+            $scope.display.calendar = false;
+            $scope.display.editEventRight = false;
+            $scope.model = model;
+            $scope.me = model.me;
+            $scope.calendarEvent = new CalendarEvent();
+            $scope.calendars = new Calendars();
+            $scope.display.importFileButtonDisabled = true;
+            $scope.calendarEvents = new CalendarEvents();
+            $scope.periods = periods;
+            $scope.newFile = {};
+            $scope.propertyName = 'startMoment';
+            $scope.reverse = true;
+            $scope.calendar = new Calendar();
+            $scope.display.selectAllCalendarEvents = false;
+            $scope.timeConfig = timeConfig;
+            $scope.recurrence = recurrence;
+            $scope.reader = new FileReader();
+            $scope.jsonData = {ics: {}};
+            $scope.calendarEvents.filters.startMoment = moment().startOf('day');
+            $scope.calendarEvents.filters.endMoment = moment().add(2, 'months').startOf('day');
+            $scope.contentToWatch = "";
+            $scope.calendarCreationScreen = false;
+            $scope.calendarAsContribRight = new Array<Calendar>();
+            $scope.selectedCalendarInEvent = new Array<Calendar>();
+            $scope.rights = rights;
+            $scope.buttonAction = ACTIONS;
+            $scope.eventSidebar$ = new Subject<void>();
 
-        template.open('main', 'main-view');
-        template.open('top-menu', 'top-menu');
+            template.open('main', 'main-view');
+            template.open('top-menu', 'top-menu');
 
-        this.$onDestroy = () => {
-            $scope.eventSidebar$.unsubscribe();
-        };
+            this.$onDestroy = () => {
+                $scope.eventSidebar$.unsubscribe();
+            };
 
-        route({
-            goToCalendar : async function(params) {
-                await Promise.all([
-                    $scope.calendars.sync(),
-                    $scope.calendars.preference.sync()
-                ]);
-                setCalendarLang();
-                $scope.loadSelectedCalendars();
-                let calendarNotification = $scope.calendars.all.filter( calendarFiltre => calendarFiltre._id === params.calendar )[0];
-                if (calendarNotification === undefined) {
-                    $scope.notFound = true;
-                    template.open('error', '404');
-                } else {
-                    $scope.notFound = false;
-                    $scope.openOrCloseCalendar(calendarNotification, true);
-                }
-            },
-            mainPage : async function()  {
-                await Promise.all([
-                    $scope.calendars.sync(),
-                    $scope.calendars.preference.sync()
-                ]);
-                $scope.loadSelectedCalendars();
+            route({
+                goToCalendar: async function (params) {
+                    await Promise.all([
+                        $scope.calendars.syncCalendars(),
+                        $scope.calendars.preference.sync()
+                    ]);
 
-                //ensure that default calendar is selected
-                let defaultCalendar : Calendar = $scope.calendars.all.find(cal => cal.is_default == true);
-                defaultCalendar.selected = false;
-                $scope.openOrCloseCalendar(defaultCalendar, true);
+                    setCalendarLang();
 
-                $scope.firstOwnedEvent();
-                $scope.initEventDates(moment().utc().second(0).millisecond(0), moment().utc().second(0).millisecond(0).add(1, 'hours'));
-                setCalendarLang();
-                $scope.$apply();
-            },
-        });
+                    await $scope.resolveSelectedCalendars();
 
-        model.calendar.on('date-change', () => {
-            $scope.calendarEvents.filtered = [];
-            $scope.$apply();
-            $scope.loadCalendarEvents();
-            $scope.$apply();
-        });
+                    let oneWeekLater: Date = model.calendar.firstDay.clone().add(7, 'd');
+                    await $scope.calendars.syncSelectedCalendarEvents(model.calendar.firstDay.format(FORMAT.formattedDate), oneWeekLater.format(FORMAT.formattedDate));
+                    $scope.loadCalendarEvents();
 
-    function disableImportFileButton() {
-        $scope.$apply(function() {
-            $scope.display.importFileButtonDisabled = false;
-        });
-    }
-
-    const setCalendarLang = ():void => {
-        model.calendar.firstDay = model.calendar.firstDay.lang(LANG_CALENDAR);
-    };
-
-    $scope.isEmpty = () => {
-        return $scope.calendars
-            && $scope.calendars.all
-            && $scope.calendars.all.length < 1;
-    }
-
-    $scope.loadCalendarEvents = () =>{
-        if($scope.calendars.all.length > 0){
-            $scope.calendarEvents.filtered = $scope.calendars.arr.map((element : Calendar) =>  element.selected ?
-                element.calendarEvents.all : []).flat();
-            $scope.calendarEvents.all = $scope.calendarEvents.filtered;
-
-            //add multi days events to multiDaysEvents array
-            $scope.calendarEvents.multiDaysEvents = $scope.calendars.arr.map((element : Calendar) =>
-                (element.calendarEvents && element.calendarEvents.multiDaysEvents) ?
-                    element.calendarEvents.multiDaysEvents : []).flat();
-        }
-        if ($scope.display.list) {
-            $scope.restoreMultiDaysEvents();
-            $scope.calendarEvents.applyFilters();
-        }
-        $scope.calendarEvents.filtered = $scope.removeDuplicateCalendarEvent($scope.calendarEvents.filtered);
-
-        /* trigger tooltip to show up */
-        let $scheduleItems: JQuery = $('.schedule-items');
-        $scheduleItems.mousemove(() => {
-            $timeout(() => safeApply($scope), 600)
-        });
-
-        safeApply($scope);
-    };
-
-    $scope.restoreMultiDaysEvents = () : void => {
-        $scope.calendarEvents.filtered = $scope.calendarEvents.filtered.filter((evt : CalendarEvent) => !evt.isMultiDayPart);
-        $scope.calendarEvents.filtered = [...$scope.calendarEvents.filtered, ...$scope.calendarEvents.multiDaysEvents];
-        $scope.calendarEvents.all = $scope.calendarEvents.filtered;
-    };
-
-    /**
-     * Remove events which are duplicated
-     */
-    $scope.removeDuplicateCalendarEvent = (events: Array<CalendarEvent>): Array<CalendarEvent> => {
-        if($scope.display.list) { //list view
-            events = events.reduce((filteredEvents : CalendarEvent[], item : CalendarEvent) => {
-                //case where all elements must have a unique _id
-                if(!(filteredEvents.find((t : CalendarEvent) => (t._id == item._id)))){
-                    filteredEvents.push(item);
-                }
-                return filteredEvents;
-            }, []);
-        } else { //calendar view
-            events = events.reduce((filteredEvents : CalendarEvent[], item : CalendarEvent) => {
-                //ensures that all events are unique:
-                //a normal event has a unique id
-                //a multi days event part is the only one with this id/startMoment/endMoment combo
-                if(!(filteredEvents.find((t : CalendarEvent) => (!(t.isMultiDayPart && !isSameMultiDayEventPart(t, item)) && (t._id == item._id))))){
-                    filteredEvents.push(item);
-                }
-                return filteredEvents;
-            }, []);
-        }
-        return events;
-    };
-
-    /** Returns true if the two events represent the same part of a multi-day event (same id, start and end moments)
-     *
-     * @param event1 first event to be compared
-     * @param event2 2nd event of the comparison
-     */
-    const isSameMultiDayEventPart =  (event1 : CalendarEvent, event2 : CalendarEvent) : boolean => {
-        return((event1._id == event2._id) && moment(event1.startMoment).isSame(moment(event2.startMoment)) && moment(event1.endMoment).isSame(moment(event2.endMoment)))
-    }
-
-
-    $scope.someSelectedValue = function(selection) {
-        return Object.keys(selection).map(function(val) { return selection[val]; }).some(function(val) { return val === true;});
-    };
-
-    $scope.changeStartMoment = () => {
-        if(!$scope.isDateValid()){
-            $scope.calendarEvent.endMoment = moment($scope.calendarEvent.startMoment);
-        } else {
-          $scope.calendarEvent.endMoment = moment($scope.calendarEvent.endMoment).toDate();
-        }
-    };
-
-    $scope.changeEndMoment = () => {
-        if(!$scope.isDateValid()){
-            $scope.calendarEvent.startMoment = moment($scope.calendarEvent.endMoment);
-        } else {
-           $scope.calendarEvent.startMoment = moment($scope.calendarEvent.startMoment).toDate();
-        }
-    };
-
-    $scope.toggleIsRecurrent = function(calendarEvent) {
-        if (calendarEvent.isRecurrent) {
-            if (!$scope.calendarEvent.recurrence.end_on) {
-                $scope.calendarEvent.recurrence.end_on = moment($scope.calendarEvent.endMoment).add(1, 'days').hours(0).minutes(0).seconds(0).milliseconds(0);
-            }
-            if(!$scope.isOneDayEvent()){
-                $scope.calendarEvent.recurrence.start_on =  moment($scope.calendarEvent.startMoment).add(1, 'days').hours(0).minutes(0).seconds(0).milliseconds(0);
-            }
-            //if the event lasts more than one day, it cannot be recurrent daily => the weekly recurrence becomes default
-            if (!$scope.calendarEvent.recurrence.type) {
-                $scope.isOneDayEvent() ? ($scope.calendarEvent.recurrence.type = 'every_day') : ($scope.calendarEvent.recurrence.type = 'every_week');
-            }
-            if (!$scope.calendarEvent.recurrence.every) {
-                $scope.calendarEvent.recurrence.every = 1;
-            }
-            if ($scope.calendarEvent.recurrence.type === 'every_week') {
-                $scope.changedRecurrenceType();
-            }
-            if(!$scope.isOneDayEvent()) $scope.changeStartMoment();
-        }
-    };
-
-    $scope.toggleDateToRecurrence = function(name) {
-        if (name === 'start') {
-            $scope.calendarEvent.endDateToRecurrence = false;
-        }
-        if (name === 'end') {
-            $scope.calendarEvent.startDateToRecurrence = false;
-        }
-    };
-
-    $scope.getDate = function(theDate) {
-        return moment(theDate).format('DD/MM/YYYY');
-    };
-
-    $scope.changedRecurrenceType = function() {
-        $scope.calendarEvent.recurrence.week_days = {1: false,2: false,3: false,4: false,5: false,6: false,7: false};
-        if ($scope.calendarEvent.recurrence.type === 'every_week') {
-            if (!$scope.someSelectedValue($scope.calendarEvent.recurrence.week_days)) {
-                let dayOfWeek : number = moment($scope.calendarEvent.startMoment).day();
-                if (dayOfWeek === 0) {
-                    dayOfWeek = 7;
-                }
-                $scope.calendarEvent.recurrence.week_days[dayOfWeek] = true;
-            }
-        }
-    };
-
-    $scope.handleRecurrence = function(calendarEvent) {
-        if (calendarEvent.recurrence) {
-            if (calendarEvent.recurrence.type == 'every_day' && calendarEvent.recurrence.every) {
-                return $scope.handleEveryDayRecurrence(calendarEvent);
-            }
-            else if (calendarEvent.recurrence.type == 'every_week') {
-                return $scope.handleEveryWeekRecurrence(calendarEvent);
-            }
-        } else {
-            return 0;
-        }
-    };
-
-    $scope.handleEveryDayRecurrence = function(calendarEvent) {
-        var calendarRecurrentEvent;
-        var list = [];
-        if (calendarEvent.recurrence.end_type == 'after' && calendarEvent.recurrence.end_after) {
-            for (let i = 0; i < calendarEvent.recurrence.end_after; i++) {
-                calendarRecurrentEvent = $scope.createChildCalendarEvent(calendarEvent);
-                calendarRecurrentEvent.index = i;
-                var toAdd = i * parseInt(calendarEvent.recurrence.every);
-                calendarRecurrentEvent.startMoment = moment(calendarEvent.startMoment).add(toAdd, 'days');
-                calendarRecurrentEvent.endMoment = moment(calendarEvent.endMoment).add(toAdd, 'days');
-                var item = {'calEvent': calendarRecurrentEvent, 'action': 'save'};
-                list.push(item);
-            }
-        } else if (calendarEvent.recurrence.end_type == 'on' && calendarEvent.recurrence.end_on) {
-            var endOnMoment = moment(calendarEvent.recurrence.end_on);
-            var startMoment = calendarEvent.startMoment;
-
-            for (let i =0; startMoment.isBefore(endOnMoment); i++) {
-                calendarRecurrentEvent = $scope.createChildCalendarEvent(calendarEvent);
-                calendarRecurrentEvent.index = i;
-                var toAdd = i * parseInt(calendarEvent.recurrence.every);
-                calendarRecurrentEvent.startMoment = moment(calendarEvent.startMoment).add(toAdd, 'days');
-                calendarRecurrentEvent.endMoment = moment(calendarEvent.endMoment).add(toAdd, 'days');
-                if (calendarRecurrentEvent.startMoment.isAfter(endOnMoment)) {
-                    break;
-                }
-                var item = {'calEvent': calendarRecurrentEvent, 'action': 'save'};
-                list.push(item);
-                startMoment = calendarRecurrentEvent.startMoment;
-            }
-        }
-        return list;
-    };
-
-    $scope.handleEveryWeekRecurrence = function(calendarEvent) {
-        let weekDays = Object.keys(calendarEvent.recurrence.week_days).filter(val =>
-            calendarEvent.recurrence.week_days[val]
-        );
-        let dayJump = 7 * calendarEvent.recurrence.every;
-        let startOn : Moment = moment(calendarEvent.recurrence.start_on);
-        let startDay = calendarEvent.recurrence.start_on.isoWeekday();
-        let startHour : Moment = moment(calendarEvent.startTime).hours();
-        let startMinute = moment(calendarEvent.startTime).minutes();
-        let duration : Moment = $scope.isOneDayEvent()
-            ? moment(calendarEvent.endTime).seconds(0).milliseconds(0).diff(moment(calendarEvent.startTime)
-                .seconds(0).milliseconds(0), 'minutes')
-            : moment(calendarEvent.endMoment).hours(calendarEvent.endTime.getHours()).minutes(calendarEvent.endTime.getMinutes())
-                .seconds(0).milliseconds(0)
-                .diff( moment(calendarEvent.startMoment).hours(calendarEvent.startTime.getHours()).minutes(calendarEvent.startTime.getMinutes())
-                    .seconds(0).milliseconds(0), 'minutes');
-        let recurrenceDays = weekDays.filter(val => val >= startDay);
-        if (recurrenceDays.length === 0) {
-            startOn.isoWeekday(1).add(dayJump, 'days');
-        } else {
-            startOn.isoWeekday(parseInt(recurrenceDays[0], 10));
-        }
-        let endOn : Moment = moment(startOn.toISOString());
-        let list = [];
-        if (calendarEvent.recurrence.end_type == 'after') {
-            while (recurrenceDays.length < calendarEvent.recurrence.end_after) {
-                recurrenceDays = recurrenceDays.concat(weekDays);
-            }
-            if (recurrenceDays.length > calendarEvent.recurrence.end_after) {
-                recurrenceDays = recurrenceDays.slice(0, calendarEvent.recurrence.end_after);
-            }
-            let previousDay = recurrenceDays[0];
-            recurrenceDays.forEach((day, idx) => {
-                if (day <= previousDay && idx > 0) {
-                    endOn.isoWeekday(1).add(dayJump, 'days');
-                }
-                endOn.isoWeekday(parseInt(day, 10));
-                let calendarRecurrentEvent = $scope.createChildCalendarEvent(calendarEvent);
-                calendarRecurrentEvent.index = idx;
-                calendarRecurrentEvent.startMoment = moment(endOn).hours(startHour).minutes(startMinute);
-                calendarRecurrentEvent.endMoment = moment(calendarRecurrentEvent.startMoment).add(duration, 'minutes');
-                var item = {'calEvent': calendarRecurrentEvent, 'action': 'save'};
-                list.push(item);
-                previousDay = day;
-            });
-        } else if (calendarEvent.recurrence.end_type == 'on') {
-            while (calendarEvent.recurrence.end_on.diff(endOn, 'days') >= 0) {
-                recurrenceDays = recurrenceDays.concat(weekDays);
-                endOn = endOn.isoWeekday(1).add(dayJump, 'days');
-            }
-            endOn = moment(startOn.toISOString());
-            if (recurrenceDays.length) {
-                let previousDay = recurrenceDays[0];
-                recurrenceDays.every((day, idx) => {
-                    if (day <= previousDay && idx > 0) {
-                        endOn = endOn.isoWeekday(1).add(dayJump, 'days');
+                    let calendarNotification = $scope.calendars.all.filter(calendarFiltre => calendarFiltre._id === params.calendar)[0];
+                    if (calendarNotification === undefined) {
+                        $scope.notFound = true;
+                        template.open('error', '404');
+                    } else {
+                        $scope.notFound = false;
+                        $scope.openOrCloseCalendar(calendarNotification, true);
                     }
-                    endOn.isoWeekday(parseInt(day, 10));
-                    if (calendarEvent.recurrence.end_on.diff(endOn, 'days') >= 0) {
+                },
+                mainPage: async function () {
+                    await Promise.all([
+                        $scope.calendars.syncCalendars(),
+                        $scope.calendars.preference.sync()
+                    ]);
+
+                    $scope.resolveSelectedCalendars();
+
+                    let defaultCalendar: Calendar = $scope.calendars.all.find(cal => cal.is_default == true);
+                    if (defaultCalendar) {
+                        defaultCalendar.selected = false;
+                        $scope.openOrCloseCalendar(defaultCalendar, true);
+                    }
+
+                    let oneWeekLater: Date = model.calendar.firstDay.clone().add(7, 'd');
+                    await $scope.calendars.syncSelectedCalendarEvents(model.calendar.firstDay.format(FORMAT.formattedDate), oneWeekLater.format(FORMAT.formattedDate));
+                    $scope.loadCalendarEvents();
+                    //ensure that default calendar is selected
+
+
+                    $scope.firstOwnedEvent();
+                    $scope.initEventDates(moment().utc().second(0).millisecond(0), moment().utc().second(0).millisecond(0).add(1, 'hours'));
+                    setCalendarLang();
+                    $scope.$apply();
+                },
+            });
+
+            model.calendar.on('date-change', async () => {
+                $scope.calendarEvents.filtered = [];
+                await updateChangeDateCalendarSchedule(model.calendar.firstDay);
+                $scope.loadCalendarEvents();
+            });
+
+            function disableImportFileButton() {
+                $scope.$apply(function () {
+                    $scope.display.importFileButtonDisabled = false;
+                });
+            }
+
+            const setCalendarLang = (): void => {
+                model.calendar.firstDay = model.calendar.firstDay.lang(LANG_CALENDAR);
+            };
+
+            /**
+             * Synchronise elements depending on the display
+             */
+            $scope.syncSelectedCalendars = async function () {
+                if (model && model.calendar && model.calendar.display && model.calendar.display.mode) {
+                    switch (model.calendar.display.mode) {
+                        case PERIODE_TYPE.DAY:
+                            let oneDayLater = model.calendar.firstDay.clone().add(1, 'd');
+                            await $scope.calendars.syncSelectedCalendarEvents(model.calendar.firstDay.format(FORMAT.formattedDate), oneDayLater.format(FORMAT.formattedDate));
+                            break;
+                        case PERIODE_TYPE.WEEK:
+                            let oneWeekLater = model.calendar.firstDay.clone().add(7, 'd');
+                            await $scope.calendars.syncSelectedCalendarEvents(model.calendar.firstDay.format(FORMAT.formattedDate), oneWeekLater.format(FORMAT.formattedDate));
+                            break;
+                        case PERIODE_TYPE.MONTH:
+                            let oneMonthLater = model.calendar.firstDay.clone().add(1, 'M');
+                            await $scope.calendars.syncSelectedCalendarEvents(model.calendar.firstDay.format(FORMAT.formattedDate), oneMonthLater.format(FORMAT.formattedDate));
+                            break;
+                    }
+                }
+            }
+
+            $scope.isEmpty = () => {
+                return $scope.calendars
+                    && $scope.calendars.all
+                    && $scope.calendars.all.length < 1;
+            }
+
+            /*
+            ** Fetch all events from selected Calendars
+             */
+            $scope.loadCalendarEvents = () => {
+                if($scope.calendars && $scope.calendars.all){
+                    if ($scope.calendars.all.length > 0) {
+                        $scope.calendarEvents.filtered = $scope.calendars.arr.map((element: Calendar) => element.selected ?
+                            element.calendarEvents.all : []).flat();
+                        $scope.calendarEvents.all = $scope.calendarEvents.filtered;
+
+                        //add multi days events to multiDaysEvents array
+                        $scope.calendarEvents.multiDaysEvents = $scope.calendars.arr.map((element: Calendar) =>
+                            (element.calendarEvents && element.calendarEvents.multiDaysEvents) ?
+                                element.calendarEvents.multiDaysEvents : []).flat();
+                    }
+                }
+                if ($scope.display.list) {
+                    $scope.restoreMultiDaysEvents();
+                    $scope.calendarEvents.applyFilters();
+                }
+                $scope.calendarEvents.filtered = $scope.removeDuplicateCalendarEvent($scope.calendarEvents.filtered);
+
+                /* trigger tooltip to show up */
+                let $scheduleItems: JQuery = $('.schedule-items');
+                $scheduleItems.mousemove(() => {
+                    $timeout(() => safeApply($scope), 600)
+                });
+
+                safeApply($scope);
+            };
+
+            $scope.restoreMultiDaysEvents = (): void => {
+                $scope.calendarEvents.filtered = $scope.calendarEvents.filtered.filter((evt: CalendarEvent) => !evt.isMultiDayPart);
+                $scope.calendarEvents.filtered = [...$scope.calendarEvents.filtered, ...$scope.calendarEvents.multiDaysEvents];
+                $scope.calendarEvents.all = $scope.calendarEvents.filtered;
+            };
+
+            /**
+             * Remove events which are duplicated
+             */
+            $scope.removeDuplicateCalendarEvent = (events: Array<CalendarEvent>): Array<CalendarEvent> => {
+                if ($scope.display.list) { //list view
+                    events = events.reduce((filteredEvents: CalendarEvent[], item: CalendarEvent) => {
+                        //case where all elements must have a unique _id
+                        if (!(filteredEvents.find((t: CalendarEvent) => (t._id == item._id)))) {
+                            filteredEvents.push(item);
+                        }
+                        return filteredEvents;
+                    }, []);
+                } else { //calendar view
+                    if(events){
+                        events = events.reduce((filteredEvents: CalendarEvent[], item: CalendarEvent) => {
+                            //ensures that all events are unique:
+                            //a normal event has a unique id
+                            //a multi days event part is the only one with this id/startMoment/endMoment combo
+                            if (!(filteredEvents.find((t: CalendarEvent) => (!(t.isMultiDayPart && !isSameMultiDayEventPart(t, item)) && (t._id == item._id))))) {
+                                filteredEvents.push(item);
+                            }
+                            return filteredEvents;
+                        }, []);
+                    }
+                }
+                return events;
+            };
+
+            /** Returns true if the two events represent the same part of a multi-day event (same id, start and end moments)
+             *
+             * @param event1 first event to be compared
+             * @param event2 2nd event of the comparison
+             */
+            const isSameMultiDayEventPart = (event1: CalendarEvent, event2: CalendarEvent): boolean => {
+                return ((event1._id == event2._id) && moment(event1.startMoment).isSame(moment(event2.startMoment)) && moment(event1.endMoment).isSame(moment(event2.endMoment)))
+            }
+
+
+            $scope.someSelectedValue = function (selection) {
+                return Object.keys(selection).map(function (val) {
+                    return selection[val];
+                }).some(function (val) {
+                    return val === true;
+                });
+            };
+
+            $scope.changeStartMoment = () => {
+                if (!$scope.isDateValid()) {
+                    $scope.calendarEvent.endMoment = moment($scope.calendarEvent.startMoment);
+                } else {
+                    $scope.calendarEvent.endMoment = moment($scope.calendarEvent.endMoment).toDate();
+                }
+            };
+
+            $scope.changeEndMoment = () => {
+                if (!$scope.isDateValid()) {
+                    $scope.calendarEvent.startMoment = moment($scope.calendarEvent.endMoment);
+                } else {
+                    $scope.calendarEvent.startMoment = moment($scope.calendarEvent.startMoment).toDate();
+                }
+            };
+
+            $scope.toggleIsRecurrent = function (calendarEvent) {
+                if (calendarEvent.isRecurrent) {
+                    if (!$scope.calendarEvent.recurrence.end_on) {
+                        $scope.calendarEvent.recurrence.end_on = moment($scope.calendarEvent.endMoment).add(1, 'days').hours(0).minutes(0).seconds(0).milliseconds(0);
+                    }
+                    if (!$scope.isOneDayEvent()) {
+                        $scope.calendarEvent.recurrence.start_on = moment($scope.calendarEvent.startMoment).add(1, 'days').hours(0).minutes(0).seconds(0).milliseconds(0);
+                    }
+                    //if the event lasts more than one day, it cannot be recurrent daily => the weekly recurrence becomes default
+                    if (!$scope.calendarEvent.recurrence.type) {
+                        $scope.isOneDayEvent() ? ($scope.calendarEvent.recurrence.type = 'every_day') : ($scope.calendarEvent.recurrence.type = 'every_week');
+                    }
+                    if (!$scope.calendarEvent.recurrence.every) {
+                        $scope.calendarEvent.recurrence.every = 1;
+                    }
+                    if ($scope.calendarEvent.recurrence.type === 'every_week') {
+                        $scope.changedRecurrenceType();
+                    }
+                    if (!$scope.isOneDayEvent()) $scope.changeStartMoment();
+                }
+            };
+
+            $scope.toggleDateToRecurrence = function (name) {
+                if (name === 'start') {
+                    $scope.calendarEvent.endDateToRecurrence = false;
+                }
+                if (name === 'end') {
+                    $scope.calendarEvent.startDateToRecurrence = false;
+                }
+            };
+
+            $scope.getDate = function (theDate) {
+                return moment(theDate).format(FORMAT.formattedDate);
+            };
+
+            $scope.changedRecurrenceType = function () {
+                $scope.calendarEvent.recurrence.week_days = {
+                    1: false,
+                    2: false,
+                    3: false,
+                    4: false,
+                    5: false,
+                    6: false,
+                    7: false
+                };
+                if ($scope.calendarEvent.recurrence.type === 'every_week') {
+                    if (!$scope.someSelectedValue($scope.calendarEvent.recurrence.week_days)) {
+                        let dayOfWeek: number = moment($scope.calendarEvent.startMoment).day();
+                        if (dayOfWeek === 0) {
+                            dayOfWeek = 7;
+                        }
+                        $scope.calendarEvent.recurrence.week_days[dayOfWeek] = true;
+                    }
+                }
+            };
+
+            $scope.handleRecurrence = function (calendarEvent) {
+                if (calendarEvent.recurrence) {
+                    if (calendarEvent.recurrence.type == 'every_day' && calendarEvent.recurrence.every) {
+                        return $scope.handleEveryDayRecurrence(calendarEvent);
+                    } else if (calendarEvent.recurrence.type == 'every_week') {
+                        return $scope.handleEveryWeekRecurrence(calendarEvent);
+                    }
+                } else {
+                    return 0;
+                }
+            };
+
+            $scope.handleEveryDayRecurrence = function (calendarEvent) {
+                var calendarRecurrentEvent;
+                var list = [];
+                if (calendarEvent.recurrence.end_type == 'after' && calendarEvent.recurrence.end_after) {
+                    for (let i = 0; i < calendarEvent.recurrence.end_after; i++) {
+                        calendarRecurrentEvent = $scope.createChildCalendarEvent(calendarEvent);
+                        calendarRecurrentEvent.index = i;
+                        var toAdd = i * parseInt(calendarEvent.recurrence.every);
+                        calendarRecurrentEvent.startMoment = moment(calendarEvent.startMoment).add(toAdd, 'days');
+                        calendarRecurrentEvent.endMoment = moment(calendarEvent.endMoment).add(toAdd, 'days');
+                        var item = {'calEvent': calendarRecurrentEvent, 'action': 'save'};
+                        list.push(item);
+                    }
+                } else if (calendarEvent.recurrence.end_type == 'on' && calendarEvent.recurrence.end_on) {
+                    var endOnMoment = moment(calendarEvent.recurrence.end_on);
+                    var startMoment = calendarEvent.startMoment;
+
+                    for (let i = 0; startMoment.isBefore(endOnMoment); i++) {
+                        calendarRecurrentEvent = $scope.createChildCalendarEvent(calendarEvent);
+                        calendarRecurrentEvent.index = i;
+                        var toAdd = i * parseInt(calendarEvent.recurrence.every);
+                        calendarRecurrentEvent.startMoment = moment(calendarEvent.startMoment).add(toAdd, 'days');
+                        calendarRecurrentEvent.endMoment = moment(calendarEvent.endMoment).add(toAdd, 'days');
+                        if (calendarRecurrentEvent.startMoment.isAfter(endOnMoment)) {
+                            break;
+                        }
+                        var item = {'calEvent': calendarRecurrentEvent, 'action': 'save'};
+                        list.push(item);
+                        startMoment = calendarRecurrentEvent.startMoment;
+                    }
+                }
+                return list;
+            };
+
+            $scope.handleEveryWeekRecurrence = function (calendarEvent) {
+                let weekDays = Object.keys(calendarEvent.recurrence.week_days).filter(val =>
+                    calendarEvent.recurrence.week_days[val]
+                );
+                let dayJump = 7 * calendarEvent.recurrence.every;
+                let startOn: Moment = moment(calendarEvent.recurrence.start_on);
+                let startDay = calendarEvent.recurrence.start_on.isoWeekday();
+                let startHour: Moment = moment(calendarEvent.startTime).hours();
+                let startMinute = moment(calendarEvent.startTime).minutes();
+                let duration: Moment = $scope.isOneDayEvent()
+                    ? moment(calendarEvent.endTime).seconds(0).milliseconds(0).diff(moment(calendarEvent.startTime)
+                        .seconds(0).milliseconds(0), 'minutes')
+                    : moment(calendarEvent.endMoment).hours(calendarEvent.endTime.getHours()).minutes(calendarEvent.endTime.getMinutes())
+                        .seconds(0).milliseconds(0)
+                        .diff(moment(calendarEvent.startMoment).hours(calendarEvent.startTime.getHours()).minutes(calendarEvent.startTime.getMinutes())
+                            .seconds(0).milliseconds(0), 'minutes');
+                let recurrenceDays = weekDays.filter(val => val >= startDay);
+                if (recurrenceDays.length === 0) {
+                    startOn.isoWeekday(1).add(dayJump, 'days');
+                } else {
+                    startOn.isoWeekday(parseInt(recurrenceDays[0], 10));
+                }
+                let endOn: Moment = moment(startOn.toISOString());
+                let list = [];
+                if (calendarEvent.recurrence.end_type == 'after') {
+                    while (recurrenceDays.length < calendarEvent.recurrence.end_after) {
+                        recurrenceDays = recurrenceDays.concat(weekDays);
+                    }
+                    if (recurrenceDays.length > calendarEvent.recurrence.end_after) {
+                        recurrenceDays = recurrenceDays.slice(0, calendarEvent.recurrence.end_after);
+                    }
+                    let previousDay = recurrenceDays[0];
+                    recurrenceDays.forEach((day, idx) => {
+                        if (day <= previousDay && idx > 0) {
+                            endOn.isoWeekday(1).add(dayJump, 'days');
+                        }
+                        endOn.isoWeekday(parseInt(day, 10));
                         let calendarRecurrentEvent = $scope.createChildCalendarEvent(calendarEvent);
                         calendarRecurrentEvent.index = idx;
                         calendarRecurrentEvent.startMoment = moment(endOn).hours(startHour).minutes(startMinute);
@@ -387,1255 +420,1319 @@ export const calendarController =  ng.controller('CalendarController',
                         var item = {'calEvent': calendarRecurrentEvent, 'action': 'save'};
                         list.push(item);
                         previousDay = day;
-                        return true;
+                    });
+                } else if (calendarEvent.recurrence.end_type == 'on') {
+                    while (calendarEvent.recurrence.end_on.diff(endOn, 'days') >= 0) {
+                        recurrenceDays = recurrenceDays.concat(weekDays);
+                        endOn = endOn.isoWeekday(1).add(dayJump, 'days');
+                    }
+                    endOn = moment(startOn.toISOString());
+                    if (recurrenceDays.length) {
+                        let previousDay = recurrenceDays[0];
+                        recurrenceDays.every((day, idx) => {
+                            if (day <= previousDay && idx > 0) {
+                                endOn = endOn.isoWeekday(1).add(dayJump, 'days');
+                            }
+                            endOn.isoWeekday(parseInt(day, 10));
+                            if (calendarEvent.recurrence.end_on.diff(endOn, 'days') >= 0) {
+                                let calendarRecurrentEvent = $scope.createChildCalendarEvent(calendarEvent);
+                                calendarRecurrentEvent.index = idx;
+                                calendarRecurrentEvent.startMoment = moment(endOn).hours(startHour).minutes(startMinute);
+                                calendarRecurrentEvent.endMoment = moment(calendarRecurrentEvent.startMoment).add(duration, 'minutes');
+                                var item = {'calEvent': calendarRecurrentEvent, 'action': 'save'};
+                                list.push(item);
+                                previousDay = day;
+                                return true;
+                            } else {
+                                return false;
+                            }
+                        });
+                    }
+                }
+                return list;
+            };
+
+            $scope.handleEveryWeekDayRecurrence = function (calendarEvent) {
+                var calendarRecurrentEvent;
+                if (calendarEvent.recurrence.end_type == 'after' && calendarEvent.recurrence.end_after) {
+                    for (let i = 0; i < calendarEvent.recurrence.end_after; i++) {
+                        calendarRecurrentEvent = $scope.createChildCalendarEvent(calendarEvent);
+                        calendarRecurrentEvent.startMoment = moment(calendarEvent.startMoment).add(i + 1, 'days');
+                        calendarRecurrentEvent.endMoment = moment(calendarEvent.endMoment).add(i + 1, 'days');
+                        $scope.saveCalendarEventEdit(calendarRecurrentEvent);
+                    }
+                }
+            };
+
+            $scope.cropEventDate = (calendarEventDate: string): string =>
+                DateUtils.getSimpleFRDateFormat(calendarEventDate);
+
+            $scope.createChildCalendarEvent = function (calendarEvent) {
+                var child = new CalendarEvent();
+                child.title = calendarEvent.title;
+                child.description = calendarEvent.description;
+                child.location = calendarEvent.location;
+                child.color = calendarEvent.color;
+                child.locked = calendarEvent.locked;
+                child.is_periodic = calendarEvent.is_periodic;
+                child.calendar = calendarEvent.calendar;
+                child.parentId = calendarEvent._id;
+                child.allday = calendarEvent.allday;
+                child.isRecurrent = calendarEvent.isRecurrent;
+                child.recurrence = calendarEvent.recurrence;
+                child.startMoment = calendarEvent.startMoment;
+                child.endMoment = calendarEvent.endMoment;
+                child.startTime = calendarEvent.startTime;
+                child.endTime = calendarEvent.endTime;
+                child.isMultiDayPart = calendarEvent.isMultiDayPart;
+                child.attachments = calendarEvent.attachments;
+                return child;
+            };
+
+
+            $scope.firstOwnedCalendar = function () {
+                return _.find($scope.calendars.all, function (calendar) {
+                    return $scope.isMyCalendar(calendar);
+                });
+            };
+
+            $scope.firstOwnedEvent = function () {
+                return _.find($scope.calendarEvents.all, function (calendarEvent) {
+                    return $scope.isMyEvent(calendarEvent);
+                });
+            };
+
+            $scope.updateCalendars = async () => {
+                let updatedCalendar = $scope.calendar;
+                let selectedCalendars = $scope.calendars.preference;
+                await Promise.all([
+                    $scope.calendars.sync(),
+                    $scope.calendars.preference.sync()
+                ]);
+                $scope.calendars.preference = selectedCalendars;
+                $scope.loadSelectedCalendars();
+                $scope.showCalendar();
+                $scope.calendar = $scope.calendars.all.find((cl: Calendar) => cl._id == updatedCalendar._id);
+                if ($scope.calendar) {
+                    $scope.calendar.selected = true;
+                    $scope.calendar.showButtons = true;
+                    $scope.display.showToggleButtons = true;
+                    $scope.eventSidebar$.next();
+                } else {
+                    $scope.display.showToggleButtons = false;
+                }
+                safeApply($scope);
+            };
+
+            /**
+             * Get all selected calendars and the events from these selected calendars
+             **/
+            $scope.loadSelectedCalendars = () => {
+                if ($scope.calendars.preference) {
+                    let toSelectCalendars: Calendar[] = $scope.calendars.all.filter(calendar => {
+                        return _.contains($scope.calendars.preference.selectedCalendars, calendar._id);
+                    });
+                    toSelectCalendars.forEach(function (cl) {
+                        $scope.openOrCloseCalendar(cl, false);
+                    });
+                }
+                if ($scope.calendars.selected.length === 0 && !$scope.calendars) {
+                    var calendarToOpen = $scope.firstOwnedCalendar();
+                    if (calendarToOpen === undefined) {
+                        calendarToOpen = $scope.calendars.all[0];
+                    }
+                    $scope.openOrCloseCalendar(calendarToOpen, true);
+                }
+            };
+
+            /**
+             * Get all selected calendars and the events from these selected calendars
+             **/
+            $scope.resolveSelectedCalendars = (): void => {
+                if ($scope.calendars.preference) {
+                    $scope.calendars.all
+                        .filter((calendar: Calendar) => _.contains($scope.calendars.preference.selectedCalendars, calendar._id))
+                        .forEach((calendar: Calendar) => calendar.selected = true);
+                }
+                if ($scope.calendars.selected.length === 0 && !$scope.calendars) {
+                    let calendarToOpen: Calendar = $scope.firstOwnedCalendar();
+                    if (calendarToOpen == undefined) {
+                        calendarToOpen = $scope.calendars.all[0];
+                    }
+                    calendarToOpen.selected = true;
+                }
+            };
+
+
+            $scope.saveCalendarPreferences = () => {
+                $scope.calendars.preference.update();
+            };
+
+            /**
+             * View events in a list
+             */
+            $scope.showList = function () {
+                $scope.display.list = true;
+                $scope.display.calendar = false;
+                $scope.display.propertyName = 'startMoment';
+                $scope.reverse = false;
+                $scope.calendarEvents.filters.startMoment = moment().startOf('day');
+                template.open('calendar', 'events-list');
+            };
+
+            $scope.sortBy = function (propertyName) {
+                $scope.reverse = ($scope.propertyName === propertyName) ? !$scope.reverse : false;
+                $scope.propertyName = propertyName;
+            };
+
+            /**
+             * View events in a grid
+             */
+            $scope.showCalendar = function () {
+                if ($scope.calendars.all.length === 0) return;
+                $scope.display.list = false;
+                $scope.display.calendar = true;
+                $scope.loadCalendarEvents();
+                template.open('calendar', 'read-calendar');
+            };
+
+            $scope.isMyCalendar = function (calendar) {
+                return calendar.owner.userId == $scope.me.userId;
+            };
+
+            /**
+             * Return true if the current user created the event
+             * @param calEvent event to check
+             */
+            $scope.isMyEvent = (calEvent: CalendarEvent): boolean => {
+                return calEvent.owner.userId === $scope.me.userId;
+            };
+
+
+            $scope.initEventDates = function (startMoment, endMoment) {
+                var event = $scope.calendarEvent;
+                var minTime = moment(startMoment);
+                minTime.set('hour', timeConfig.start_hour);
+                var maxTime = moment(endMoment);
+                maxTime.set('hour', timeConfig.end_hour);
+                if (startMoment.isAfter(minTime) && startMoment.isBefore(maxTime)) {
+                    event.startMoment = startMoment;
+                } else {
+                    if (startMoment.isAfter(maxTime)) {
+                        startMoment.add(1, 'days');
+                        endMoment.add(1, 'days');
+                        maxTime.add(1, 'days');
+                    }
+                }
+                if (endMoment.isBefore(maxTime)) {
+                    event.endMoment = endMoment;
+                }
+            };
+
+            $scope.openOrCloseCalendar = async function (calendar, savePreferences) {
+                if ($scope.calendars.selected.length > 1 || !calendar.selected) {
+                    calendar.selected = !calendar.selected;
+                    if (calendar.selected) {
+                        $scope.calendar = calendar;
+                    }
+                    $scope.display.editEventRight = $scope.hasContribRight();
+                    $scope.calendarEvents.applyFilters();
+                    if (!$scope.display.list && !$scope.display.calendar) {
+                        $scope.showCalendar();
+                    } else {
+                        $scope.loadCalendarEvents();
+                    }
+                    if (savePreferences) {
+                        $scope.calendars.preference.selectedCalendars = $scope.calendars.selectedElements.map(element => element._id);
+                        if ($scope.calendar && $scope.calendar.selected) {
+                            $scope.calendars.preference.selectedCalendars = [...$scope.calendars.preference.selectedCalendars, calendar._id];
+                        } else {
+                            $scope.calendars.preference.selectedCalendars = $scope.calendars.preference.selectedCalendars.filter(element => element !== calendar._id)
+                        }
+                        await $scope.saveCalendarPreferences();
+                        await $scope.loadCalendarEvents();
+                    }
+                }
+            };
+
+
+            $scope.newCalendar = function () {
+                $scope.calendarCreationScreen = true;
+                $scope.calendar = new Calendar();
+                $scope.calendar.color = defaultColor;
+                template.open('calendar', 'edit-calendar');
+            };
+
+            $scope.resetMultipleDayEventInfo = (originalEvent: CalendarEvent): void => {
+                $scope.calendarEvent.startMoment = originalEvent.startMoment;
+                $scope.calendarEvent.endMoment = originalEvent.endMoment;
+
+                let startDate: Moment = moment(originalEvent.startMoment).second(0).millisecond(0);
+                let endDate: Moment = moment(originalEvent.endMoment).second(0).millisecond(0);
+                $scope.calendarEvent.startTime = makerFormatTimeInput(moment(startDate), moment(startDate));
+                ;
+                $scope.calendarEvent.endTime = makerFormatTimeInput(moment(endDate), moment(endDate));
+            };
+
+            /**
+             *Allows to view an event creation form
+             *
+             * @param calendarEvent the created event
+             * @param isCalendar allows to use the lightbox from the calendar directive
+             */
+            $scope.viewCalendarEvent = (calendarEvent, isCalendar ?: boolean) => {
+                $scope.calendarEvent = new CalendarEvent(calendarEvent);
+                if (calendarEvent.isMultiDayPart) {
+                    let originalEvent: CalendarEvent = $scope.calendarEvents.multiDaysEvents.find((item: CalendarEvent) => item._id == calendarEvent._id);
+                    originalEvent == undefined ? toasts.warning(lang.translate('calendar.event.get.error')) : $scope.resetMultipleDayEventInfo(originalEvent);
+                }
+                $scope.calendar = calendarEvent.calendar[0];
+                $scope.createContentToWatch();
+                $scope.calendarEvent.showDetails = true;
+                if (!$scope.calendarEvent.parentId) {
+                    if (!$scope.calendarEvent.recurrence) {
+                        $scope.calendarEvent.recurrence = {};
+                        $scope.calendarEvent.recurrence.week_days = recurrence.week_days;
+                    }
+                }
+                if (!isCalendar) {
+                    if (($scope.hasManageRightOrIsEventOwner(calendarEvent) && $scope.hasRightOnSharedEvent(calendarEvent, rights.resources.updateEvent.right))
+                        && calendarEvent.editAllRecurrence == undefined
+                        && calendarEvent.isRecurrent && calendarEvent._id) {
+                        template.open('recurrenceLightbox', 'recurrent-event-edition-popup');
+                        $scope.display.showRecurrencePanel = true;
+                    } else if (!calendarEvent._id || ($scope.hasManageRightOrIsEventOwner(calendarEvent) && $scope.hasRightOnSharedEvent(calendarEvent, rights.resources.updateEvent.right))) {
+                        if (calendarEvent.editAllRecurrence) {
+                            //event content
+                            $scope.calendarEvent.detailToRecurrence = true;
+                            //event date/length
+                            $scope.calendarEvent.startDateToRecurrence = true;
+                            $scope.calendarEvent.endDateToRecurrence = true;
+                        }
+                        $scope.display.showRecurrencePanel = false;
+                        template.close('recurrenceLightbox');
+                        template.open('lightbox', 'edit-event');
+                        $scope.display.showEventPanel = true;
+                    } else {
+                        template.open('lightbox', 'view-event');
+                        $scope.display.showEventPanel = true;
+                    }
+
+                }
+            };
+
+            $scope.closeCalendarEvent = () => {
+                if (!$scope.calendarEvent.title) {
+                    $scope.eventForm = angular.element(document.getElementById("event-form")).scope();
+                    $scope.eventForm.form.$setPristine();
+                    $scope.eventForm.form.$setUntouched();
+                    $scope.$apply();
+                }
+                template.close('lightbox');
+                $scope.showCalendarEventTimePicker = false;
+                $scope.refreshCalendarEvents();
+                $scope.display.showEventPanel = false;
+                $scope.contentToWatch = "";
+            };
+
+            $scope.unselectRecurrenceRemovalCheckbox = (uncheckDeleteAllRecurrence: boolean): void => {
+                if (uncheckDeleteAllRecurrence) {
+                    $scope.calendarEvent.deleteAllRecurrence = false;
+                } else {
+                    $scope.calendarEvent.noMoreRecurrent = false;
+                    $scope.calendarEvent.noMoreRecurrence = false;
+                }
+            };
+
+            $scope.confirmRemoveCalendarEvent = (calendarEvent: CalendarEvent, event): void => {
+                $scope.calendar.calendarEvents.deselectAll();
+                if (calendarEvent.editAllRecurrence) {
+                    calendarEvent.deleteAllRecurrence = true;
+                }
+                if (calendarEvent.deleteAllRecurrence) {
+                    selectOtherRecurrentEvents(calendarEvent);
+                }
+                if (calendarEvent.noMoreRecurrent && calendarEvent.noMoreRecurrence) {
+                    selectOtherRecurrentEvents(calendarEvent);
+                    let clickedEvent: CalendarEvent = $scope.calendarEvents.getRecurrenceEvents(calendarEvent)
+                        .find((calEvent: CalendarEvent) => calEvent && calEvent._id && calEvent._id === calendarEvent._id);
+                    if (clickedEvent) clickedEvent.selected = false;
+                }
+                $scope.display.confirmDeleteCalendarEvent = true;
+                event.stopPropagation();
+            };
+
+            $scope.confirmRemoveCalendarEvents = function (event) {
+                template.open('lightbox');
+                $scope.calendarEvents.selected.forEach(calendarEvent => {
+                    if (calendarEvent.deleteAllRecurrence) {
+                        selectOtherRecurrentEvents(calendarEvent);
+                    }
+                });
+                $scope.display.confirmDeleteCalendarEvent = true;
+            };
+
+            /**
+             * Select all recurrent events associated to the current event
+             * @param calendarEvent calendar Event
+             */
+            const selectOtherRecurrentEvents = (calendarEvent: CalendarEvent): void => {
+                if (calendarEvent.isMultiDayPart) {
+                    $scope.restoreMultiDaysEvents();
+                }
+                let reccurentEvents = $scope.removeDuplicateCalendarEvent($scope.calendarEvents.getRecurrenceEvents(calendarEvent));
+                reccurentEvents.forEach(calEvent => {
+                    calEvent.selected = true;
+                });
+            };
+
+            /**
+             * Allow delete all recurrent events of an event when it is display in list
+             * @param calendarEvent calendar event
+             */
+            $scope.deleteAllRecurrenceList = (calendarEvent: CalendarEvent): void => {
+                $scope.calendarEvent = calendarEvent;
+                $scope.calendarEvent.deleteAllRecurrence = true;
+                $scope.confirmRemoveCalendarEvents(null);
+
+            }
+
+            $scope.removeCalendarEvents = () => {
+                let count = $scope.calendarEvents.selected.length;
+                let countReccurent = 0;
+                if ($scope.calendarEvents.selected.length === 0) {
+                    let eventsCalendar = new CalendarEvent($scope.calendarEvent);
+                    eventsCalendar.delete();
+                    $scope.resetCalendarAfterRemoveEvent(count, countReccurent);
+                } else {
+                    $scope.calendarEvents.selected.forEach(calendarEvent => {
+                        calendarEvent.delete();
+                        count--;
+                        $scope.resetCalendarAfterRemoveEvent(count, countReccurent);
+                    });
+                }
+                $scope.calendarEvents.deselectAll();
+                $scope.display.selectAllCalendarEvents = $scope.display.selectAllCalendarEvents && false;
+                if ($scope.calendarEvent.noMoreRecurrence) {
+                    $scope.calendarEvent.isRecurrent = false;
+                    $scope.calendarEvent.recurrence = false;
+                    $scope.calendarEvent.parentId = false;
+                    $scope.calendarEvent.index = 0;
+                    $scope.calendarEvent.save();
+                    $scope.refreshCalendarEvents();
+                }
+                template.close('lightbox');
+                $scope.display.confirmDeleteCalendarEvent = false;
+            };
+
+            const addCssOnHtmlElement = (selectorHtml: string, propertyCss: string, valueCss: string): void => {
+                $(selectorHtml).css(propertyCss, valueCss);
+            }
+
+            $scope.refreshCalendarEvents = async () => {
+                template.close('lightbox');
+                await $scope.calendars.syncCalendarEvents();
+                await $scope.loadCalendarEvents();
+                addCssOnHtmlElement("body > portal > div > section", "z-index", "9000");
+                $scope.$apply();
+            };
+
+
+            $scope.resetCalendarAfterRemoveEvent = async function (count, countRecurrent) {
+                if (count === 0 && countRecurrent === 0) {
+                    await $scope.refreshCalendarEvents();
+                    $scope.closeCalendarEvent();
+                    if ($scope.display.list && $scope.display.selectAllCalendarEvents) {
+                        $scope.display.selectAllCalendarEvents = undefined;
+                    }
+                    $scope.display.confirmDeleteCalendarEvent = false;
+                }
+            };
+
+            $scope.cancelRemoveCalendarEvent = function () {
+                $scope.display.confirmDeleteCalendarEvent = undefined;
+                $scope.calendarEvent.deleteAllRecurrence = false;
+                $scope.calendarEvents.forEach(function (calendarEvent) {
+                    calendarEvent.selected = false;
+                });
+            };
+
+            $scope.editCalendar = function (calendar, event) {
+                $scope.calendar = calendar;
+                event.stopPropagation();
+                template.open('calendar', 'edit-calendar');
+                $scope.createContentToWatch();
+            };
+
+            $scope.createContentToWatch = function () {
+                if ($scope.calendarEvent.title == undefined) {
+                    $scope.contentToWatch = "";
+                } else {
+                    $scope.contentToWatch = $scope.calendarEvent.title;
+                }
+                if ($scope.calendarEvent.description != undefined) {
+                    $scope.contentToWatch += $scope.calendarEvent.description;
+                }
+                if ($scope.calendarEvent.location != undefined) {
+                    $scope.contentToWatch += $scope.calendarEvent.location;
+                }
+            };
+
+            $scope.saveCalendarEdit = async () => {
+                if ($scope.calendar._id) {
+                    await $scope.calendar.save();
+                    $scope.updateCalendars();
+                    await $scope.calendar.calendarEvents.sync($scope.calendar, $scope.calendars);
+                    $scope.calendarEvents.applyFilters();
+                } else {
+                    await $scope.calendar.save();
+                    $scope.openOrCloseCalendar($scope.calendar, true);
+                    await $scope.calendars.sync();
+                    $scope.loadSelectedCalendars();
+                    $scope.loadCalendarEvents();
+                }
+                safeApply($scope);
+                $scope.showCalendar();
+                $scope.calendarCreationScreen = false;
+            };
+
+            /**
+             * Return true if the user as the right to manage the calendar of the event or if he created the event and he can contrib
+             * to the calendar
+             * @param calEvent event to check
+             */
+            $scope.hasManageRightOrIsEventOwner = (calEvent: CalendarEvent): boolean => {
+                return $scope.smallerRightEvent(calEvent) == "manage" ||
+                    ($scope.isMyEvent(calEvent) && $scope.smallerRightEvent(calEvent) == "contrib");
+            }
+
+            $scope.hasContribRight = calendar => {
+                if (calendar) {
+                    return calendar.myRights.contrib;
+                } else {
+                    return $scope.calendars.all.some(function (cl) {
+                        if (cl.myRights.contrib && cl.selected) {
+                            return true;
+                        }
+                    });
+                }
+            };
+
+            $scope.hasRightOnSharedEvent = (calEvent: CalendarEvent, right: string): boolean => {
+                if (!calEvent.shared || calEvent.owner.userId === $scope.me.userId) {
+                    return true;
+                } else {
+                    let numberOfRights: number;
+                    numberOfRights = (calEvent.shared
+                        .filter(share => share[right]
+                            && (share["userId"] === $scope.me.userId
+                                || $scope.me.groupsIds.includes(share["groupId"]))).length);
+
+                    return (numberOfRights > 0);
+                }
+            }
+
+            $scope.hasReadRight = function (calendar) {
+                if (calendar) {
+                    return calendar.myRights.contrib;
+                } else {
+                    return $scope.calendars.selected.some(function (cl) {
+                        if (cl.myRights.contrib) {
+                            return true;
+                        }
+                    });
+                }
+            };
+
+            $scope.cancelCalendarEdit = function () {
+                $scope.calendarCreationScreen = false;
+                $scope.calendar = undefined;
+
+                if ($scope.isEmpty()) {
+                    template.close('calendar');
+                } else {
+                    template.open('calendar', 'read-calendar');
+                }
+            };
+
+            $scope.confirmRemoveCalendar = function (calendar, event) {
+                $scope.display.confirmDeleteCalendar = true;
+                $scope.calendar = calendar;
+                event.stopPropagation();
+
+            };
+
+
+            $scope.removeCalendar = async () => {
+                $scope.display.showToggleButtons = false;
+                $scope.calendar.calendarEvents.forEach(function (calendarEvent) {
+                    calendarEvent.delete();
+                });
+
+                try {
+                    await $scope.calendar.delete();
+                } catch (err) {
+                    let error: AxiosResponse = err.response;
+                    if (error.status === 403) {
+                        toasts.warning(error.data.error);
+                    } else {
+                        toasts.warning(lang.translate('calendar.delete.error'));
+                    }
+                }
+                if ($scope.calendars.all.length === 1) {
+                    template.close("calendar");
+                }
+                await $scope.calendars.sync();
+                await $scope.loadSelectedCalendars();
+                $scope.loadCalendarEvents();
+                template.close('lightbox');
+                $scope.display.confirmDeleteCalendar = undefined;
+                $scope.$apply();
+            };
+
+            $scope.cancelRemoveCalendar = function () {
+                $scope.display.confirmDeleteCalendar = undefined;
+            };
+
+            $scope.shareCalendar = function (calendar, event) {
+                $scope.calendar = calendar;
+                $scope.display.showPanelCalendar = true;
+                event.stopPropagation();
+            };
+
+            $scope.shareEvent = function (calendarEvent, event) {
+                $scope.calendarEvent = calendarEvent;
+                $scope.display.showPanelEvent = true;
+                event.stopPropagation();
+            };
+
+            $scope.saveAndShareEvent = async function (calendarEvent, event) {
+                try {
+                    $scope.sendNotif = false;
+                    await $scope.saveCalendarEventEdit(calendarEvent, event, true);
+                    $scope.sendNotif = true;
+                } catch (err) {
+                    $scope.display.showPanelEvent = false;
+                    let error: AxiosResponse = err.response;
+                    if (error.status === 401) {
+                        toasts.warning(error.data.error);
+                    } else {
+                        toasts.warning(lang.translate('calendar.event.save.error'));
+                    }
+                }
+                ;
+            }
+
+            $scope.nameOfShareButton = (calendarEvent: CalendarEvent, view: "calendar" | "list"): string => {
+                if (!calendarEvent || !calendarEvent.calendar) {
+                    return "";
+                }
+
+                let numberOfSharedCalendars: number = calendarEvent.calendar
+                    .filter((calendar: Calendar): boolean => calendar.shared && (calendar.shared.length !== 0))
+                    .length;
+
+                const isShared = (): boolean => numberOfSharedCalendars > 0;
+
+                switch (view) {
+                    case "calendar":
+                        return lang.translate(`calendar.event.save.and.${isShared() ? 'restrict' : 'share'}`);
+                    case "list":
+                        return lang.translate(`calendar.event.${isShared() ? 'restrict' : 'share'}`);
+                    default:
+                        return "";
+                }
+            }
+
+            /**
+             * Prepare $scope.calendarEvent to create the event and call the method that will display the calendar creation form
+             * @param newItem the event information so far
+             * @param isCalendar allows to use the lightbox from the calendar directive
+             */
+            $scope.createCalendarEvent = (newItem?, isCalendar?: boolean) => {
+                $scope.calendarAsContribRight = new Array<Calendar>();
+                $scope.selectedCalendarInEvent = new Array<Calendar>();
+                $scope.calendarEvent = new CalendarEvent();
+                $scope.calendarEvent.recurrence = {};
+                $scope.calendarEvent.calendar = new Array<Calendar>();
+                isCalendar ? $scope.viewCalendarEvent($scope.calendarEvent, isCalendar)
+                    : $scope.viewCalendarEvent($scope.calendarEvent);
+                setListCalendarWithContribFilter();
+                $scope.calendarAsContribRight.forEach((calendar: Calendar) => {
+                    calendar.toString = () => {
+                        return calendar.title
+                    };
+                });
+                safeApply($scope);
+
+                if (newItem) {
+                    $scope.calendarEvent.startMoment = newItem.beginning;
+                    $scope.calendarEvent.startMoment = $scope.calendarEvent.startMoment.minute(0).second(0).millisecond(0);
+                    $scope.calendarEvent.endMoment = newItem.end;
+                    $scope.calendarEvent.endMoment = $scope.calendarEvent.endMoment.minute(0).second(0).millisecond(0);
+                } else {
+                    $scope.calendarEvent.startMoment = moment.utc().second(0).millisecond(0).add(utcTime($scope.calendarEvent.startMoment), 'hours');
+                    $scope.calendarEvent.endMoment = moment.utc().second(0).millisecond(0).add(5 - utcTime($scope.calendarEvent.endMoment), 'hours');
+                }
+                $scope.calendarEvent.startTime = makerFormatTimeInput($scope.calendarEvent.startMoment, $scope.calendarEvent.startMoment);
+                $scope.calendarEvent.endTime = makerFormatTimeInput($scope.calendarEvent.endMoment, $scope.calendarEvent.startMoment);
+                $scope.calendarEvent.recurrence.week_days = recurrence.week_days;
+                $scope.calendarEvent.calendar = $scope.calendars.selected[$scope.calendars.selected.length - 1];
+                $scope.changeCalendarEventCalendar();
+                $scope.calendarEvent.showDetails = true;
+                $scope.initEventDates($scope.calendarEvent.startMoment, $scope.calendarEvent.endMoment);
+                $scope.showCalendarEventTimePicker = true;
+            };
+            //unique
+            const unique = function <T>(array: T[]) {
+                return array.filter(function (value, index, self) {
+                    return self.indexOf(value) === index;
+                });
+            }
+            /**
+             *   Put the calendars that the user has the right to modify in calendarAsContribRight and tick the first in the list
+             */
+            const setListCalendarWithContribFilter = (): void => {
+                $scope.calendars.arr.forEach(
+                    function (calendar) {
+                        if ($scope.hasContribRight(calendar) != null) {
+                            $scope.calendarAsContribRight.push(calendar);
+                        }
+                    });
+                $scope.calendarAsContribRight = unique($scope.calendarAsContribRight);
+                let defaultCalendar: Calendar = $scope.calendarAsContribRight.find(cal => cal.is_default == true);
+                $scope.selectedCalendarInEvent.push(defaultCalendar ? defaultCalendar : $scope.calendarAsContribRight[0]);
+                $scope.selectedCalendarInEvent = unique($scope.selectedCalendarInEvent);
+            }
+
+            /**
+             *  Verify if there is a element tick in the multi-combo of calendars
+             */
+            $scope.isCalendarSelectedInEvent = (): boolean => {
+                if ($scope.calendarEvent._id) {
+                    return true;
+                } else {
+                    return $scope.selectedCalendarInEvent.length != 0;
+                }
+            };
+
+            /**
+             * Remove the selected calendar from the list of selected calendars
+             * @param calendar name of the selected calendar
+             */
+            $scope.dropCalendar = (calendar: String): void => {
+                $scope.selectedCalendarInEvent = _.without($scope.selectedCalendarInEvent, calendar);
+                $scope.changeCalendarEventCalendar();
+            };
+
+            /**
+             *  Update the calendars of the calendar event
+             */
+            $scope.changeCalendarEventCalendar = (): void => {
+                $scope.calendarEvent.calendar = new Array<Calendar>();
+
+                $scope.selectedCalendarInEvent.forEach(
+                    function (selectedCalendars) {
+                        $scope.calendars.arr.forEach(
+                            function (calendar) {
+                                if (selectedCalendars._id === calendar._id) {
+                                    $scope.calendarEvent.calendar.push(calendar);
+                                }
+                            });
+                    });
+            }
+
+            /**
+             * Return the name of the smaller right
+             * @param event the calendar event
+             */
+            $scope.smallerRightEvent = (event: CalendarEvent): string => {
+                let right = "manage";
+                event.calendar.filter(e => e != null).forEach(
+                    function (calendar) {
+                        if ($scope.hasContribRight(calendar)) {
+                            if (!calendar.myRights.manage && right != "read") {
+                                right = "contrib";
+                            }
+                        } else {
+                            right = "read";
+                        }
+                    }
+                )
+                return right;
+            }
+
+            /**
+             * Verify if one of the calendar of the event as the right of manage or if the event is created by the user and he
+             * as one of his calendar with the right of contrib
+             * @param event calendar event to check
+             */
+            $scope.hasACalendarWithRightsOfModifyEvent = (event: CalendarEvent): boolean => {
+                let right = false
+                event.calendar.forEach(
+                    function (calendar) {
+                        if ($scope.hasContribRight(calendar)) {
+                            if (calendar.myRights.manage || $scope.isMyEvent(event)) {
+                                right = true;
+                            }
+                        }
+                    }
+                );
+                return right;
+            }
+
+            $scope.displayImportIcsPanel = function () {
+                $scope.display.showImportPanel = true;
+                $scope.display.importFileButtonDisabled = true;
+                $scope.newFile.name = '';
+            };
+
+            $scope.setFilename = async () => {
+                if ($scope.newFile && $scope.newFile.files && $scope.newFile.files.length > 0) {
+                    $scope.newFile.name = $scope.newFile.files[0].name;
+                    await $scope.reader.readAsText($scope.newFile.files[0], 'UTF-8');
+                    $scope.reader.onloadend = async () => {
+                        return $scope.jsonData.ics = $scope.reader.result;
+                    };
+                    disableImportFileButton();
+                }
+            };
+            $scope.importIcsFile = async (calendar, event) => {
+                event.currentTarget.disabled = true;
+                await $scope.calendar.importIcal($scope.jsonData);
+                $scope.icsImport = $scope.calendar.icsImport;
+                $scope.display.showImportPanel = undefined;
+                $scope.display.showImportReport = true;
+                $scope.importFileButtonDisabled = true;
+                await $scope.calendar.calendarEvents.sync($scope.calendar, $scope.calendars);
+                $scope.loadCalendarEvents();
+                if ($scope.display.list) {
+                    $scope.showList();
+                } else {
+                    $scope.showCalendar();
+                }
+            };
+
+            $scope.verifyInputDates = function () {
+                if ($scope.calendarEvent.title) {
+                    $scope.calendarEvent.showDates = true;
+                } else {
+                    $scope.calendarEvent.showDetails = true;
+                }
+            };
+
+            $scope.verifyInputRec = function () {
+                if ($scope.calendarEvent.title) {
+                    $scope.calendarEvent.showRecurrence = true;
+                } else {
+                    $scope.calendarEvent.showDetails = true;
+                }
+            };
+
+            $scope.canICloseLightBox = function () {
+                if ($scope.calendarEvent.title == undefined && $scope.calendarEvent.description == undefined && $scope.calendarEvent.location == undefined) {
+                    return false;
+                } else {
+                    let toCompare = "";
+                    if ($scope.calendarEvent.title != undefined) {
+                        toCompare += $scope.calendarEvent.title;
+                    }
+                    if ($scope.calendarEvent.description != undefined) {
+                        toCompare += $scope.calendarEvent.description;
+                    }
+                    if ($scope.calendarEvent.location != undefined) {
+                        toCompare += $scope.calendarEvent.location;
+                    }
+                    if ($scope.contentToWatch != toCompare) {
+                        return !confirm(lang.translate("calendar.navigation.guard"));
                     } else {
                         return false;
                     }
-                });
-            }
-        }
-        return list;
-    };
-
-    $scope.handleEveryWeekDayRecurrence = function(calendarEvent) {
-        var calendarRecurrentEvent;
-        if (calendarEvent.recurrence.end_type == 'after' && calendarEvent.recurrence.end_after) {
-            for (let i = 0; i < calendarEvent.recurrence.end_after; i++) {
-                calendarRecurrentEvent = $scope.createChildCalendarEvent(calendarEvent);
-                calendarRecurrentEvent.startMoment = moment(calendarEvent.startMoment).add(i + 1, 'days');
-                calendarRecurrentEvent.endMoment = moment(calendarEvent.endMoment).add(i + 1, 'days');
-                $scope.saveCalendarEventEdit(calendarRecurrentEvent);
-            }
-        }
-    };
-
-    $scope.cropEventDate = (calendarEventDate : string): string =>
-        DateUtils.getSimpleFRDateFormat(calendarEventDate);
-
-    $scope.createChildCalendarEvent = function(calendarEvent) {
-        var child  = new CalendarEvent();
-        child.title = calendarEvent.title;
-        child.description = calendarEvent.description;
-        child.location = calendarEvent.location;
-        child.color = calendarEvent.color;
-        child.locked = calendarEvent.locked;
-        child.is_periodic = calendarEvent.is_periodic;
-        child.calendar = calendarEvent.calendar;
-        child.parentId = calendarEvent._id;
-        child.allday = calendarEvent.allday;
-        child.isRecurrent = calendarEvent.isRecurrent;
-        child.recurrence = calendarEvent.recurrence;
-        child.startMoment = calendarEvent.startMoment;
-        child.endMoment = calendarEvent.endMoment;
-        child.startTime = calendarEvent.startTime;
-        child.endTime = calendarEvent.endTime;
-        child.isMultiDayPart = calendarEvent.isMultiDayPart;
-        child.attachments = calendarEvent.attachments;
-        return child;
-    };
-
-
-
-    $scope.firstOwnedCalendar = function() {
-        return _.find($scope.calendars.all, function(calendar) {
-            return $scope.isMyCalendar(calendar);
-        });
-    };
-
-    $scope.firstOwnedEvent = function() {
-        return _.find($scope.calendarEvents.all, function(calendarEvent) {
-            return $scope.isMyEvent(calendarEvent);
-        });
-    };
-
-    $scope.updateCalendars = async () => {
-        let updatedCalendar = $scope.calendar;
-        let selectedCalendars = $scope.calendars.preference;
-        await Promise.all([
-            $scope.calendars.sync(),
-            $scope.calendars.preference.sync()
-        ]);
-        $scope.calendars.preference = selectedCalendars;
-        $scope.loadSelectedCalendars();
-        $scope.showCalendar();
-        $scope.calendar = $scope.calendars.all.find((cl :Calendar) => cl._id == updatedCalendar._id);
-        if($scope.calendar) {
-            $scope.calendar.selected = true;
-            $scope.calendar.showButtons = true;
-            $scope.display.showToggleButtons = true;
-            $scope.eventSidebar$.next();
-        } else {
-            $scope.display.showToggleButtons = false;
-        }
-        safeApply($scope);
-    };
-
-    $scope.loadSelectedCalendars = () => {
-        if ($scope.calendars.preference) {
-            var toSelectCalendars = $scope.calendars.all.filter(calendar => {
-                return _.contains($scope.calendars.preference.selectedCalendars, calendar._id);
-            });
-            toSelectCalendars.forEach(function(cl) {
-               $scope.openOrCloseCalendar(cl, false);
-            });
-        }
-        if ($scope.calendars.selected.length === 0 && !$scope.calendars) {
-            var calendarToOpen = $scope.firstOwnedCalendar();
-            if (calendarToOpen === undefined) {
-                calendarToOpen = $scope.calendars.all[0];
-            }
-            $scope.openOrCloseCalendar(calendarToOpen, true);
-        }
-    };
-
-
-
-    $scope.saveCalendarPreferences = () => {
-        $scope.calendars.preference.update();
-    };
-
-    /**
-     * View events in a list
-     */
-    $scope.showList = function() {
-        $scope.display.list = true;
-        $scope.display.calendar = false;
-        $scope.display.propertyName = 'startMoment';
-        $scope.reverse = false;
-        $scope.loadCalendarEvents();
-        template.open('calendar', 'events-list');
-    };
-
-    $scope.sortBy = function(propertyName) {
-        $scope.reverse = ($scope.propertyName === propertyName) ? !$scope.reverse : false;
-        $scope.propertyName = propertyName;
-    };
-
-    /**
-     * View events in a grid
-     */
-    $scope.showCalendar = function() {
-        if($scope.calendars.all.length === 0) return;
-        $scope.display.list = false;
-        $scope.display.calendar = true;
-        $scope.loadCalendarEvents();
-        template.open('calendar', 'read-calendar');
-    };
-
-    $scope.isMyCalendar = function(calendar) {
-        return calendar.owner.userId == $scope.me.userId;
-    };
-
-    /**
-     * Return true if the current user created the event
-     * @param calEvent event to check
-     */
-    $scope.isMyEvent = (calEvent : CalendarEvent): boolean => {
-        return calEvent.owner.userId === $scope.me.userId;
-    };
-
-
-    $scope.initEventDates = function(startMoment, endMoment) {
-        var event = $scope.calendarEvent;
-        var minTime = moment(startMoment);
-        minTime.set('hour', timeConfig.start_hour);
-        var maxTime = moment(endMoment);
-        maxTime.set('hour', timeConfig.end_hour);
-        if(startMoment.isAfter(minTime) && startMoment.isBefore(maxTime)){
-            event.startMoment = startMoment;
-        }
-        else{
-            if(startMoment.isAfter(maxTime)){
-                startMoment.add(1, 'days');
-                endMoment.add(1, 'days');
-                maxTime.add(1, 'days');
-            }
-        }
-        if(endMoment.isBefore(maxTime)){
-            event.endMoment = endMoment;
-        }
-    };
-
-    $scope.openOrCloseCalendar = async function(calendar, savePreferences) {
-        if ($scope.calendars.selected.length > 1 || !calendar.selected) {
-            calendar.selected = !calendar.selected;
-            if (calendar.selected) {
-                $scope.calendar = calendar;
-            }
-            $scope.display.editEventRight = $scope.hasContribRight();
-            $scope.calendarEvents.applyFilters();
-            if (!$scope.display.list && !$scope.display.calendar) {
-                $scope.showCalendar();
-            } else {
-                $scope.loadCalendarEvents();
-            }
-            if (savePreferences) {
-                $scope.calendars.preference.selectedCalendars = $scope.calendars.selectedElements.map(element => element._id);
-                if($scope.calendar && $scope.calendar.selected){
-                    $scope.calendars.preference.selectedCalendars = [...$scope.calendars.preference.selectedCalendars, calendar._id] ;
-                } else {
-                    $scope.calendars.preference.selectedCalendars = $scope.calendars.preference.selectedCalendars.filter(element => element !== calendar._id)
                 }
-                await $scope.saveCalendarPreferences();
-                await $scope.loadCalendarEvents();
-            }
-        }
-    };
-
-
-    $scope.newCalendar = function() {
-        $scope.calendarCreationScreen = true;
-        $scope.calendar = new Calendar();
-        $scope.calendar.color = defaultColor;
-        template.open('calendar', 'edit-calendar');
-    };
-
-    $scope.resetMultipleDayEventInfo = (originalEvent : CalendarEvent) : void => {
-        $scope.calendarEvent.startMoment = originalEvent.startMoment;
-        $scope.calendarEvent.endMoment = originalEvent.endMoment;
-
-        let startDate : Moment = moment(originalEvent.startMoment).second(0).millisecond(0);
-        let endDate : Moment = moment(originalEvent.endMoment).second(0).millisecond(0);
-        $scope.calendarEvent.startTime = makerFormatTimeInput(moment(startDate), moment(startDate));;
-        $scope.calendarEvent.endTime = makerFormatTimeInput(moment(endDate), moment(endDate));
-    };
-
-    /**
-     *Allows to view an event creation form
-     *
-     * @param calendarEvent the created event
-     * @param isCalendar allows to use the lightbox from the calendar directive
-     */
-    $scope.viewCalendarEvent = (calendarEvent, isCalendar ? : boolean) => {
-        $scope.calendarEvent = new CalendarEvent(calendarEvent);
-        if(calendarEvent.isMultiDayPart){
-            let originalEvent : CalendarEvent = $scope.calendarEvents.multiDaysEvents.find((item : CalendarEvent) => item._id == calendarEvent._id);
-            originalEvent == undefined ? toasts.warning(lang.translate('calendar.event.get.error')) : $scope.resetMultipleDayEventInfo(originalEvent);
-        }
-        $scope.calendar = calendarEvent.calendar[0];
-        $scope.createContentToWatch();
-        $scope.calendarEvent.showDetails = true;
-         if (!$scope.calendarEvent.parentId) {
-             if (!$scope.calendarEvent.recurrence) {
-                 $scope.calendarEvent.recurrence = {};
-                 $scope.calendarEvent.recurrence.week_days = recurrence.week_days;
-             }
-        }
-         if (!isCalendar){
-             if (($scope.hasManageRightOrIsEventOwner(calendarEvent) && $scope.hasRightOnSharedEvent(calendarEvent, rights.resources.updateEvent.right))
-                 && calendarEvent.editAllRecurrence == undefined
-                 && calendarEvent.isRecurrent && calendarEvent._id){
-                 template.open('recurrenceLightbox', 'recurrent-event-edition-popup');
-                 $scope.display.showRecurrencePanel = true;
-             } else if(!calendarEvent._id || ($scope.hasManageRightOrIsEventOwner(calendarEvent) && $scope.hasRightOnSharedEvent(calendarEvent, rights.resources.updateEvent.right))) {
-                 if (calendarEvent.editAllRecurrence){
-                     //event content
-                     $scope.calendarEvent.detailToRecurrence = true;
-                     //event date/length
-                     $scope.calendarEvent.startDateToRecurrence = true;
-                     $scope.calendarEvent.endDateToRecurrence = true;
-                 }
-                 $scope.display.showRecurrencePanel = false;
-                 template.close('recurrenceLightbox');
-                 template.open('lightbox', 'edit-event');
-                 $scope.display.showEventPanel = true;
-             } else {
-                 template.open('lightbox', 'view-event');
-                 $scope.display.showEventPanel = true;
-             }
-
-         }
-    };
-
-    $scope.closeCalendarEvent = () => {
-        if(!$scope.calendarEvent.title){
-            $scope.eventForm = angular.element(document.getElementById("event-form")).scope();
-            $scope.eventForm.form.$setPristine();
-            $scope.eventForm.form.$setUntouched();
-            $scope.$apply();
-        }
-        template.close('lightbox');
-        $scope.showCalendarEventTimePicker = false;
-        $scope.refreshCalendarEvents();
-        $scope.display.showEventPanel = false;
-        $scope.contentToWatch = "";
-    };
-
-    $scope.unselectRecurrenceRemovalCheckbox = (uncheckDeleteAllRecurrence: boolean): void => {
-        if (uncheckDeleteAllRecurrence) {
-            $scope.calendarEvent.deleteAllRecurrence = false;
-        } else {
-            $scope.calendarEvent.noMoreRecurrent = false;
-            $scope.calendarEvent.noMoreRecurrence = false;
-        }
-    };
-
-    $scope.confirmRemoveCalendarEvent = (calendarEvent: CalendarEvent, event): void => {
-        $scope.calendar.calendarEvents.deselectAll();
-        if (calendarEvent.editAllRecurrence) {
-            calendarEvent.deleteAllRecurrence = true;
-        }
-        if (calendarEvent.deleteAllRecurrence) {
-            selectOtherRecurrentEvents(calendarEvent);
-        }
-        if (calendarEvent.noMoreRecurrent && calendarEvent.noMoreRecurrence) {
-            selectOtherRecurrentEvents(calendarEvent);
-            let clickedEvent: CalendarEvent = $scope.calendarEvents.getRecurrenceEvents(calendarEvent)
-                .find((calEvent: CalendarEvent) => calEvent && calEvent._id && calEvent._id === calendarEvent._id);
-            if (clickedEvent) clickedEvent.selected = false;
-        }
-        $scope.display.confirmDeleteCalendarEvent = true;
-        event.stopPropagation();
-    };
-
-    $scope.confirmRemoveCalendarEvents = function(event){
-        template.open('lightbox');
-        $scope.calendarEvents.selected.forEach(calendarEvent => {
-            if (calendarEvent.deleteAllRecurrence) {
-                selectOtherRecurrentEvents(calendarEvent);
-            }
-        });
-        $scope.display.confirmDeleteCalendarEvent = true;
-    };
-
-    /**
-     * Select all recurrent events associated to the current event
-     * @param calendarEvent calendar Event
-     */
-    const selectOtherRecurrentEvents = (calendarEvent: CalendarEvent): void => {
-        if(calendarEvent.isMultiDayPart){
-            $scope.restoreMultiDaysEvents();
-        }
-        let reccurentEvents = $scope.removeDuplicateCalendarEvent($scope.calendarEvents.getRecurrenceEvents(calendarEvent));
-        reccurentEvents.forEach(calEvent => {
-            calEvent.selected = true;
-        });
-    };
-
-    /**
-     * Allow delete all recurrent events of an event when it is display in list
-     * @param calendarEvent calendar event
-     */
-    $scope.deleteAllRecurrenceList = (calendarEvent: CalendarEvent): void => {
-        $scope.calendarEvent = calendarEvent;
-        $scope.calendarEvent.deleteAllRecurrence = true;
-        $scope.confirmRemoveCalendarEvents(null);
-
-    }
-
-    $scope.removeCalendarEvents = () => {
-        let count = $scope.calendarEvents.selected.length;
-        let countReccurent = 0;
-        if ($scope.calendarEvents.selected.length === 0){
-            let eventsCalendar = new CalendarEvent($scope.calendarEvent);
-            eventsCalendar.delete();
-            $scope.resetCalendarAfterRemoveEvent(count,countReccurent);
-        } else {
-             $scope.calendarEvents.selected.forEach( calendarEvent => {
-                    calendarEvent.delete();
-                    count--;
-                    $scope.resetCalendarAfterRemoveEvent(count,countReccurent);
-            });
-        }
-        $scope.calendarEvents.deselectAll();
-        $scope.display.selectAllCalendarEvents = $scope.display.selectAllCalendarEvents && false;
-        if ($scope.calendarEvent.noMoreRecurrence){
-            $scope.calendarEvent.isRecurrent = false;
-            $scope.calendarEvent.recurrence = false;
-            $scope.calendarEvent.parentId = false;
-            $scope.calendarEvent.index = 0;
-            $scope.calendarEvent.save();
-            $scope.refreshCalendarEvents();
-        }
-        template.close('lightbox');
-        $scope.display.confirmDeleteCalendarEvent = false;
-    };
-
-    const addCssOnHtmlElement = (selectorHtml:string, propertyCss:string, valueCss:string):void => {
-        $(selectorHtml).css(propertyCss,valueCss);
-    }
-
-    $scope.refreshCalendarEvents = async () => {
-        template.close('lightbox');
-        await $scope.calendars.syncCalendarEvents();
-        await $scope.loadCalendarEvents();
-        addCssOnHtmlElement("body > portal > div > section","z-index","9000");
-        $scope.$apply();
-    };
-
-
-    $scope.resetCalendarAfterRemoveEvent = async function(count,countRecurrent) {
-        if (count === 0 && countRecurrent === 0) {
-             await $scope.refreshCalendarEvents();
-             $scope.closeCalendarEvent();
-            if ($scope.display.list && $scope.display.selectAllCalendarEvents) {
-                $scope.display.selectAllCalendarEvents = undefined;
-            }
-            $scope.display.confirmDeleteCalendarEvent = false;
-        }
-    };
-
-    $scope.cancelRemoveCalendarEvent = function() {
-        $scope.display.confirmDeleteCalendarEvent = undefined;
-        $scope.calendarEvent.deleteAllRecurrence = false;
-        $scope.calendarEvents.forEach(function(calendarEvent) {
-            calendarEvent.selected = false;
-        });
-    };
-
-    $scope.editCalendar = function(calendar, event) {
-        $scope.calendar = calendar;
-        event.stopPropagation();
-        template.open('calendar', 'edit-calendar');
-        $scope.createContentToWatch();
-    };
-
-    $scope.createContentToWatch = function(){
-        if($scope.calendarEvent.title == undefined){
-            $scope.contentToWatch = "";
-        }else{
-            $scope.contentToWatch = $scope.calendarEvent.title;
-        }
-        if($scope.calendarEvent.description != undefined){
-            $scope.contentToWatch += $scope.calendarEvent.description;
-        }
-        if($scope.calendarEvent.location != undefined){
-            $scope.contentToWatch += $scope.calendarEvent.location;
-        }
-    };
-
-    $scope.saveCalendarEdit = async () => {
-        if ($scope.calendar._id) {
-            await $scope.calendar.save();
-            $scope.updateCalendars();
-            await $scope.calendar.calendarEvents.sync($scope.calendar, $scope.calendars);
-            $scope.calendarEvents.applyFilters();
-        } else {
-            await $scope.calendar.save();
-            $scope.openOrCloseCalendar($scope.calendar, true);
-            await $scope.calendars.sync();
-            $scope.loadSelectedCalendars();
-            $scope.loadCalendarEvents();
-        }
-        safeApply($scope);
-        $scope.showCalendar();
-        $scope.calendarCreationScreen = false;
-    };
-
-    /**
-     * Return true if the user as the right to manage the calendar of the event or if he created the event and he can contrib
-     * to the calendar
-     * @param calEvent event to check
-     */
-    $scope.hasManageRightOrIsEventOwner = (calEvent : CalendarEvent): boolean => {
-        return $scope.smallerRightEvent(calEvent) == "manage" ||
-            ($scope.isMyEvent(calEvent) && $scope.smallerRightEvent(calEvent) == "contrib");
-    }
-
-    $scope.hasContribRight = calendar => {
-        if (calendar) {
-           return calendar.myRights.contrib;
-        } else {
-             return $scope.calendars.all.some(function(cl) {
-                if (cl.myRights.contrib && cl.selected) {
-                   return true;
-                }
-            });
-        }
-    };
-
-    $scope.hasRightOnSharedEvent = (calEvent : CalendarEvent, right : string): boolean => {
-        if (!calEvent.shared || calEvent.owner.userId === $scope.me.userId){
-            return true;
-        } else {
-            let numberOfRights : number;
-            numberOfRights = (calEvent.shared
-                .filter(share => share[right]
-                    && (share["userId"] === $scope.me.userId
-                    || $scope.me.groupsIds.includes(share["groupId"]))).length);
-
-            return (numberOfRights>0);
-        }
-    }
-
-    $scope.hasReadRight = function(calendar) {
-        if (calendar) {
-            return calendar.myRights.contrib;
-        } else {
-            return $scope.calendars.selected.some(function(cl) {
-                if (cl.myRights.contrib) {
-                    return true;
-                }
-            });
-        }
-    };
-
-    $scope.cancelCalendarEdit = function() {
-        $scope.calendarCreationScreen = false;
-        $scope.calendar = undefined;
-
-        if ($scope.isEmpty()) {
-            template.close('calendar');
-        } else {
-            template.open('calendar', 'read-calendar');
-        }
-    };
-
-    $scope.confirmRemoveCalendar = function(calendar, event){
-        $scope.display.confirmDeleteCalendar = true;
-        $scope.calendar = calendar;
-        event.stopPropagation();
-
-    };
-
-
-    $scope.removeCalendar = async () => {
-        $scope.display.showToggleButtons = false;
-        $scope.calendar.calendarEvents.forEach(function(calendarEvent) {
-            calendarEvent.delete();
-        });
-
-        try {
-            await $scope.calendar.delete();
-        } catch (err) {
-            let error: AxiosResponse = err.response;
-            if (error.status === 403) {
-                toasts.warning(error.data.error);
-            } else {
-                toasts.warning(lang.translate('calendar.delete.error'));
-            }
-        }
-        if($scope.calendars.all.length === 1) {
-            template.close("calendar");
-        }
-        await $scope.calendars.sync();
-        await $scope.loadSelectedCalendars();
-        $scope.loadCalendarEvents();
-        template.close('lightbox');
-        $scope.display.confirmDeleteCalendar = undefined;
-        $scope.$apply();
-    };
-
-    $scope.cancelRemoveCalendar = function() {
-        $scope.display.confirmDeleteCalendar = undefined;
-    };
-
-    $scope.shareCalendar = function(calendar, event) {
-        $scope.calendar = calendar;
-        $scope.display.showPanelCalendar = true;
-        event.stopPropagation();
-    };
-
-    $scope.shareEvent = function(calendarEvent, event) {
-        $scope.calendarEvent = calendarEvent;
-        $scope.display.showPanelEvent = true;
-        event.stopPropagation();
-    };
-
-    $scope.saveAndShareEvent = async function(calendarEvent, event) {
-        try {
-            $scope.sendNotif = false;
-            await $scope.saveCalendarEventEdit(calendarEvent, event, true);
-            $scope.sendNotif = true;
-        } catch (err)  {
-            $scope.display.showPanelEvent = false;
-            let error: AxiosResponse = err.response;
-            if (error.status === 401){
-                toasts.warning(error.data.error);
-            } else {
-                toasts.warning(lang.translate('calendar.event.save.error'));
-            }
-        };
-    }
-
-    $scope.nameOfShareButton = (calendarEvent: CalendarEvent, view: "calendar"|"list") : string => {
-        if (!calendarEvent || !calendarEvent.calendar) {
-            return "";
-        }
-
-        let numberOfSharedCalendars: number = calendarEvent.calendar
-            .filter((calendar:Calendar): boolean => calendar.shared && (calendar.shared.length !== 0))
-            .length;
-
-        const isShared = (): boolean => numberOfSharedCalendars > 0;
-
-        switch(view) {
-            case "calendar":
-                return lang.translate(`calendar.event.save.and.${isShared() ? 'restrict' : 'share'}`);
-            case "list":
-                return lang.translate(`calendar.event.${isShared() ? 'restrict' : 'share'}`);
-            default:
-                return "";
-        }
-    }
-
-    /**
-     * Prepare $scope.calendarEvent to create the event and call the method that will display the calendar creation form
-     * @param newItem the event information so far
-     * @param isCalendar allows to use the lightbox from the calendar directive
-     */
-    $scope.createCalendarEvent = (newItem?, isCalendar? :boolean) => {
-        $scope.calendarAsContribRight = new Array<Calendar>();
-        $scope.selectedCalendarInEvent = new Array<Calendar>();
-        $scope.calendarEvent = new CalendarEvent();
-        $scope.calendarEvent.recurrence = {};
-        $scope.calendarEvent.calendar = new Array<Calendar>();
-        isCalendar ? $scope.viewCalendarEvent($scope.calendarEvent, isCalendar)
-            : $scope.viewCalendarEvent($scope.calendarEvent);
-        setListCalendarWithContribFilter();
-        $scope.calendarAsContribRight.forEach((calendar : Calendar) => {
-            calendar.toString = () => { return calendar.title };
-        });
-        safeApply($scope);
-
-        if(newItem){
-            $scope.calendarEvent.startMoment = newItem.beginning;
-            $scope.calendarEvent.startMoment = $scope.calendarEvent.startMoment.minute(0).second(0).millisecond(0);
-            $scope.calendarEvent.endMoment = newItem.end;
-            $scope.calendarEvent.endMoment = $scope.calendarEvent.endMoment.minute(0).second(0).millisecond(0);
-        } else {
-            $scope.calendarEvent.startMoment = moment.utc().second(0).millisecond(0).add(utcTime($scope.calendarEvent.startMoment), 'hours');
-            $scope.calendarEvent.endMoment = moment.utc().second(0).millisecond(0).add(5 - utcTime($scope.calendarEvent.endMoment), 'hours');
-        }
-        $scope.calendarEvent.startTime = makerFormatTimeInput($scope.calendarEvent.startMoment, $scope.calendarEvent.startMoment);
-        $scope.calendarEvent.endTime = makerFormatTimeInput($scope.calendarEvent.endMoment, $scope.calendarEvent.startMoment);
-        $scope.calendarEvent.recurrence.week_days = recurrence.week_days;
-        $scope.calendarEvent.calendar = $scope.calendars.selected[$scope.calendars.selected.length - 1];
-        $scope.changeCalendarEventCalendar();
-        $scope.calendarEvent.showDetails = true;
-        $scope.initEventDates($scope.calendarEvent.startMoment, $scope.calendarEvent.endMoment);
-        $scope.showCalendarEventTimePicker = true;
-    };
-    //unique
-    const unique = function<T>(array:T[]) {
-        return array.filter(function (value, index, self) {
-            return self.indexOf(value) === index;
-        });
-    }
-    /**
-    *   Put the calendars that the user has the right to modify in calendarAsContribRight and tick the first in the list
-    */
-    const setListCalendarWithContribFilter = (): void => {
-        $scope.calendars.arr.forEach(
-            function(calendar){
-                if($scope.hasContribRight(calendar) != null){
-                    $scope.calendarAsContribRight.push(calendar);
-                }
-            });
-        $scope.calendarAsContribRight = unique($scope.calendarAsContribRight);
-        let defaultCalendar : Calendar = $scope.calendarAsContribRight.find(cal => cal.is_default == true);
-        $scope.selectedCalendarInEvent.push(defaultCalendar ? defaultCalendar : $scope.calendarAsContribRight[0]);
-        $scope.selectedCalendarInEvent = unique($scope.selectedCalendarInEvent);
-    }
-
-    /**
-     *  Verify if there is a element tick in the multi-combo of calendars
-     */
-    $scope.isCalendarSelectedInEvent = (): boolean => {
-        if($scope.calendarEvent._id){
-            return true;
-        } else {
-            return $scope.selectedCalendarInEvent.length != 0;
-        }
-    };
-
-    /**
-     * Remove the selected calendar from the list of selected calendars
-     * @param calendar name of the selected calendar
-     */
-    $scope.dropCalendar = (calendar: String): void => {
-        $scope.selectedCalendarInEvent = _.without($scope.selectedCalendarInEvent, calendar);
-        $scope.changeCalendarEventCalendar();
-    };
-
-    /**
-     *  Update the calendars of the calendar event
-     */
-    $scope.changeCalendarEventCalendar = (): void => {
-        $scope.calendarEvent.calendar = new Array<Calendar>();
-
-        $scope.selectedCalendarInEvent.forEach(
-            function(selectedCalendars){
-                $scope.calendars.arr.forEach(
-                    function(calendar){
-                        if(selectedCalendars._id === calendar._id){
-                            $scope.calendarEvent.calendar.push(calendar);
-                        }
-                });
-        });
-    }
-
-    /**
-     * Return the name of the smaller right
-     * @param event the calendar event
-     */
-    $scope.smallerRightEvent = (event : CalendarEvent): string => {
-        let right = "manage";
-        event.calendar.filter(e=>e != null).forEach(
-            function(calendar){
-                if($scope.hasContribRight(calendar)){
-                    if(!calendar.myRights.manage && right != "read"){
-                        right = "contrib";
-                    }
-                } else {
-                    right = "read";
-                }
-            }
-        )
-        return right;
-    }
-
-    /**
-     * Verify if one of the calendar of the event as the right of manage or if the event is created by the user and he
-     * as one of his calendar with the right of contrib
-     * @param event calendar event to check
-     */
-    $scope.hasACalendarWithRightsOfModifyEvent = (event : CalendarEvent): boolean => {
-        let right = false
-        event.calendar.forEach(
-            function(calendar) {
-                if ($scope.hasContribRight(calendar)) {
-                    if (calendar.myRights.manage || $scope.isMyEvent(event)) {
-                        right = true;
-                    }
-                }
-            }
-        );
-        return right;
-    }
-
-    $scope.displayImportIcsPanel = function() {
-        $scope.display.showImportPanel = true;
-        $scope.display.importFileButtonDisabled = true;
-        $scope.newFile.name = '';
-    };
-
-    $scope.setFilename = async () => {
-    	if($scope.newFile && $scope.newFile.files && $scope.newFile.files.length > 0) {
-        	$scope.newFile.name = $scope.newFile.files[0].name;
-            await $scope.reader.readAsText($scope.newFile.files[0], 'UTF-8');
-            $scope.reader.onloadend = async () => {
-                return $scope.jsonData.ics = $scope.reader.result;
             };
-            disableImportFileButton();
-    	}
-    };
-    $scope.importIcsFile = async (calendar, event) => {
-        event.currentTarget.disabled = true;
-        await $scope.calendar.importIcal($scope.jsonData);
-        $scope.icsImport = $scope.calendar.icsImport;
-        $scope.display.showImportPanel = undefined;
-        $scope.display.showImportReport = true;
-        $scope.importFileButtonDisabled = true;
-        await $scope.calendar.calendarEvents.sync($scope.calendar, $scope.calendars);
-        $scope.loadCalendarEvents();
-        if ($scope.display.list) {
-            $scope.showList();
-        }else {
-            $scope.showCalendar();
-        }
-    };
 
-    $scope.verifyInputDates = function() {
-        if($scope.calendarEvent.title){
-            $scope.calendarEvent.showDates = true;
-        }
-        else{
-            $scope.calendarEvent.showDetails = true;
-        }
-    };
+            $scope.saveCalendarEventEdit = async (calendarEvent = $scope.calendarEvent, event ?, shareOption ?: boolean) => {
 
-        $scope.verifyInputRec = function() {
-        if($scope.calendarEvent.title){
-            $scope.calendarEvent.showRecurrence = true;
-        }
-        else{
-            $scope.calendarEvent.showDetails = true;
-        }
-    };
+                const recurrenceItemsMinimumLength: number = 3;
+                /** indicates if the event is being created, in which case its id does not exist yet*/
+                const isEventCreated: boolean = !calendarEvent._id;
 
-    $scope.canICloseLightBox = function() {
-        if($scope.calendarEvent.title == undefined && $scope.calendarEvent.description == undefined && $scope.calendarEvent.location == undefined){
-            return false;
-        } else {
-            let toCompare = "";
-            if($scope.calendarEvent.title != undefined){
-                toCompare += $scope.calendarEvent.title;
-            }
-            if($scope.calendarEvent.description != undefined){
-                toCompare += $scope.calendarEvent.description;
-            }
-            if($scope.calendarEvent.location != undefined){
-                toCompare += $scope.calendarEvent.location;
-            }
-            if ($scope.contentToWatch != toCompare) {
-                return !confirm(lang.translate("calendar.navigation.guard"));
-            } else {
-                return false;
-            }
-        }
-    };
-
-    $scope.saveCalendarEventEdit = async (calendarEvent = $scope.calendarEvent, event ?, shareOption ? : boolean) => {
-
-        const recurrenceItemsMinimumLength:number = 3;
-        /** indicates if the event is being created, in which case its id does not exist yet*/
-        const isEventCreated: boolean = !calendarEvent._id;
-
-        async function doItemCalendarEvent(items, count) {
-            /**
-             * Resets elements before closing event saving
-             */
-            function endRecurrenceSave() : void {
-                calendarEvent.noMoreRecurrent = calendarEvent.noMoreRecurrent && false;
-                calendarEvent.noMoreRecurrence = calendarEvent.noMoreRecurrence && false;
-                calendarEvent.detailToRecurrence = calendarEvent.detailToRecurrence && false;
-                calendarEvent.startDateToRecurrence = calendarEvent.startDateToRecurrence && false;
-                calendarEvent.endDateToRecurrence = calendarEvent.endDateToRecurrence && false;
-                $scope.closeCalendarEvent();
-                $scope.calendarEvents.applyFilters();
-                $scope.display.calendar = true;
-                if (shareOption) {
-                    if (calendarEvent.isRecurrent && !calendarEvent.created){
-                        if (!$scope.display.showEventPanel) {
-                            $scope.shareEvent($scope.recurrentCalendarEventToShare ? $scope.recurrentCalendarEventToShare : {}, event);
+                async function doItemCalendarEvent(items, count) {
+                    /**
+                     * Resets elements before closing event saving
+                     */
+                    function endRecurrenceSave(): void {
+                        calendarEvent.noMoreRecurrent = calendarEvent.noMoreRecurrent && false;
+                        calendarEvent.noMoreRecurrence = calendarEvent.noMoreRecurrence && false;
+                        calendarEvent.detailToRecurrence = calendarEvent.detailToRecurrence && false;
+                        calendarEvent.startDateToRecurrence = calendarEvent.startDateToRecurrence && false;
+                        calendarEvent.endDateToRecurrence = calendarEvent.endDateToRecurrence && false;
+                        $scope.closeCalendarEvent();
+                        $scope.calendarEvents.applyFilters();
+                        $scope.display.calendar = true;
+                        if (shareOption) {
+                            if (calendarEvent.isRecurrent && !calendarEvent.created) {
+                                if (!$scope.display.showEventPanel) {
+                                    $scope.shareEvent($scope.recurrentCalendarEventToShare ? $scope.recurrentCalendarEventToShare : {}, event);
+                                }
+                            } else {
+                                $scope.shareEvent($scope.calendarEvent, event);
+                            }
                         }
-                    } else {
-                        $scope.shareEvent($scope.calendarEvent, event);
                     }
-                }
-            }
 
-            if (!$scope.calendarEvent.isRecurrent || calendarEvent._id || items.length >= recurrenceItemsMinimumLength
-            || !$scope.isDateValid() || !$scope.areRecurrenceAndEventLengthsCompatible())  {
-                if (items.length === count) {
-                    endRecurrenceSave();
-                } else {
-                    items[count].calEvent.owner = {
-                        userId: model.me.userId,
-                        displayName: model.me.username
-                    };
-                    let itemCalendarEvent : any = items[count].calEvent;
-                    let action : string = items[count].action;
-                    if (action === ACTIONS.save) {
-                        if (itemCalendarEvent.isRecurrent && count!== 0) {
-                            var parentId : string = items[0].calEvent._id;
-                            if (items[0].calEvent.parentId) {
-                                parentId = items[0].calEvent.parentId;
-                            }
-                            if ($scope.recurrentCalendarEventToShare === null) {
-                                $scope.recurrentCalendarEventToShare = items[count].calEvent;
-                            }
-                            itemCalendarEvent.parentId = parentId;
-                        }
-                        if (!itemCalendarEvent.created && $scope.sendNotif === false){
-                            itemCalendarEvent.sendNotif = $scope.sendNotif;
-                        }
-                        if(isEventCreated && items.length === recurrenceItemsMinimumLength
-                            && ($scope.isOneDayEvent() || itemCalendarEvent.isRecurrent)){
-                            itemCalendarEvent.isRecurrent = false;
-                            itemCalendarEvent.recurrence = false;
-                            itemCalendarEvent.parentId = false;
-                            itemCalendarEvent.index = 0;
-                        }
-                        itemCalendarEvent.save()
-                            .then(() => {
-                                items[count].calEvent._id =  itemCalendarEvent._id;
+                    if (!$scope.calendarEvent.isRecurrent || calendarEvent._id || items.length >= recurrenceItemsMinimumLength
+                        || !$scope.isDateValid() || !$scope.areRecurrenceAndEventLengthsCompatible()) {
+                        if (items.length === count) {
+                            endRecurrenceSave();
+                        } else {
+                            items[count].calEvent.owner = {
+                                userId: model.me.userId,
+                                displayName: model.me.username
+                            };
+                            let itemCalendarEvent: any = items[count].calEvent;
+                            let action: string = items[count].action;
+                            if (action === ACTIONS.save) {
+                                if (itemCalendarEvent.isRecurrent && count !== 0) {
+                                    var parentId: string = items[0].calEvent._id;
+                                    if (items[0].calEvent.parentId) {
+                                        parentId = items[0].calEvent.parentId;
+                                    }
+                                    if ($scope.recurrentCalendarEventToShare === null) {
+                                        $scope.recurrentCalendarEventToShare = items[count].calEvent;
+                                    }
+                                    itemCalendarEvent.parentId = parentId;
+                                }
+                                if (!itemCalendarEvent.created && $scope.sendNotif === false) {
+                                    itemCalendarEvent.sendNotif = $scope.sendNotif;
+                                }
+                                if (isEventCreated && items.length === recurrenceItemsMinimumLength
+                                    && ($scope.isOneDayEvent() || itemCalendarEvent.isRecurrent)) {
+                                    itemCalendarEvent.isRecurrent = false;
+                                    itemCalendarEvent.recurrence = false;
+                                    itemCalendarEvent.parentId = false;
+                                    itemCalendarEvent.index = 0;
+                                }
+                                itemCalendarEvent.save()
+                                    .then(() => {
+                                        items[count].calEvent._id = itemCalendarEvent._id;
+                                        count++;
+                                        doItemCalendarEvent(items, count);
+                                    })
+                                    .catch((e) => {
+                                        console.error(e);
+                                        notify.error(lang.translate('calendar.error.date.saving'));
+                                        count = items.length;
+                                        doItemCalendarEvent(items, count);
+                                    })
+                            } else {
+                                await itemCalendarEvent.delete();
                                 count++;
                                 doItemCalendarEvent(items, count);
-                            })
-                            .catch((e) =>{
-                                console.error(e);
-                                notify.error(lang.translate('calendar.error.date.saving'));
-                                count = items.length;
-                                doItemCalendarEvent(items, count);
-                            })
+                            }
+                        }
                     } else {
-                        await itemCalendarEvent.delete();
-                        count++;
-                        doItemCalendarEvent(items, count);
+                        toasts.warning(lang.translate('calendar.error.date.saving'));
+                        endRecurrenceSave();
+                    }
+
+                }
+
+                $scope.recurrentCalendarEventToShare = null;
+                $scope.createContentToWatch();
+                let items = [];
+                calendarEvent.startMoment = moment(calendarEvent.startMoment).seconds(0).milliseconds(0);
+                calendarEvent.endMoment = moment(calendarEvent.endMoment).seconds(0).milliseconds(0);
+                $scope.display.calendar = false;
+                let hasExistingRecurrence: boolean = false;
+                if (calendarEvent.isMultiDayPart && calendarEvent.editAllRecurrence) $scope.restoreMultiDaysEvents();
+                let recurrentCalendarEvents = $scope.calendarEvents.getRecurrenceEvents(calendarEvent);
+
+                if (recurrentCalendarEvents.length > 1) {
+                    hasExistingRecurrence = true;
+                }
+                if (calendarEvent.isRecurrent && !calendarEvent.parentId && !hasExistingRecurrence) {
+                    calendarEvent.recurrence.start_on = moment(calendarEvent.startMoment).hours(0).minutes(0).seconds(0).milliseconds(0);
+                    if (calendarEvent.recurrence.end_on) {
+                        calendarEvent.recurrence.end_on = moment(calendarEvent.recurrence.end_on).hours(0).minutes(0).seconds(0).milliseconds(0);
                     }
                 }
-            } else {
-                toasts.warning(lang.translate('calendar.error.date.saving'));
-                endRecurrenceSave();
-            }
-
-        }
-        $scope.recurrentCalendarEventToShare = null;
-        $scope.createContentToWatch();
-        let items = [];
-        calendarEvent.startMoment = moment(calendarEvent.startMoment).seconds(0).milliseconds(0);
-        calendarEvent.endMoment = moment(calendarEvent.endMoment).seconds(0).milliseconds(0);
-        $scope.display.calendar = false;
-        let hasExistingRecurrence : boolean = false;
-        if(calendarEvent.isMultiDayPart && calendarEvent.editAllRecurrence) $scope.restoreMultiDaysEvents();
-        let recurrentCalendarEvents = $scope.calendarEvents.getRecurrenceEvents(calendarEvent);
-
-        if (recurrentCalendarEvents.length > 1) {
-            hasExistingRecurrence = true;
-        }
-        if (calendarEvent.isRecurrent && !calendarEvent.parentId && !hasExistingRecurrence) {
-            calendarEvent.recurrence.start_on = moment(calendarEvent.startMoment).hours(0).minutes(0).seconds(0).milliseconds(0);
-            if (calendarEvent.recurrence.end_on) {
-                calendarEvent.recurrence.end_on = moment(calendarEvent.recurrence.end_on).hours(0).minutes(0).seconds(0).milliseconds(0);
-            }
-        }
-        if (calendarEvent.noMoreRecurrent || calendarEvent.noMoreRecurrence) {
-            calendarEvent.isRecurrent = false;
-        }
-        if (!calendarEvent.isRecurrent) {
-            if (calendarEvent.recurrence) {
-               calendarEvent.recurrence = false;
-            }
-            if (calendarEvent.parentId) {
-               calendarEvent.parentId = false;
-            }
-            calendarEvent.index = 0;
-        }
-
-        let parentAction : string = ACTIONS.create;
-        if (calendarEvent._id) {
-            parentAction = ACTIONS.update;
-        }
-        let item = {'calEvent': calendarEvent, 'action': ACTIONS.save};
-        items.push(item);
-        if (calendarEvent.isRecurrent && !calendarEvent.parentId && !hasExistingRecurrence) {
-            Array.prototype.push.apply(items, $scope.handleRecurrence(calendarEvent));
-        }
-        if (calendarEvent.isRecurrent && !calendarEvent.parentId) {
-            let item = {'calEvent': calendarEvent, 'action': ACTIONS.delete};
-            if (parentAction === ACTIONS.create) {
-                items.push(item);
-            } else if (items.length > 1) {
-                items.push(item);
-            } else {
-                calendarEvent.parentId = calendarEvent._id;
-                item.action = ACTIONS.save;
-                items.push(item);
-            }
-        }
-        if (calendarEvent.noMoreRecurrent && hasExistingRecurrence && calendarEvent.noMoreRecurrence) {
-            recurrentCalendarEvents.forEach(function(cle) {
-                if (cle._id !== calendarEvent._id) {
-                    let item = {'calEvent': cle, 'action': ACTIONS.delete};
-                    items.push(item);
+                if (calendarEvent.noMoreRecurrent || calendarEvent.noMoreRecurrence) {
+                    calendarEvent.isRecurrent = false;
                 }
-            });
-        }
-        if ((calendarEvent.detailToRecurrence ||
-            calendarEvent.startDateToRecurrence ||
-            calendarEvent.endDateToRecurrence) &&
-            calendarEvent.parentId) {
-            recurrentCalendarEvents.forEach (function(cle) {
-                if (cle._id !== calendarEvent._id) {
-                    let save : boolean = false;
-                    if (calendarEvent.detailToRecurrence) {
-                        cle.title = calendarEvent.title;
-                        cle.description = calendarEvent.description;
-                        cle.location = calendarEvent.location;
-                        save = true;
+                if (!calendarEvent.isRecurrent) {
+                    if (calendarEvent.recurrence) {
+                        calendarEvent.recurrence = false;
                     }
-                    if (calendarEvent.startDateToRecurrence
-                    && !calendarEvent.allday && !cle.allday
-                    && !moment(cle.startMoment).hours($scope.calendarEvent.startMoment.hours())
-                            .minutes($scope.calendarEvent.startMoment.minutes()).isAfter(cle.endMoment, 'minute')) {
+                    if (calendarEvent.parentId) {
+                        calendarEvent.parentId = false;
+                    }
+                    calendarEvent.index = 0;
+                }
+
+                let parentAction: string = ACTIONS.create;
+                if (calendarEvent._id) {
+                    parentAction = ACTIONS.update;
+                }
+                let item = {'calEvent': calendarEvent, 'action': ACTIONS.save};
+                items.push(item);
+                if (calendarEvent.isRecurrent && !calendarEvent.parentId && !hasExistingRecurrence) {
+                    Array.prototype.push.apply(items, $scope.handleRecurrence(calendarEvent));
+                }
+                if (calendarEvent.isRecurrent && !calendarEvent.parentId) {
+                    let item = {'calEvent': calendarEvent, 'action': ACTIONS.delete};
+                    if (parentAction === ACTIONS.create) {
+                        items.push(item);
+                    } else if (items.length > 1) {
+                        items.push(item);
+                    } else {
+                        calendarEvent.parentId = calendarEvent._id;
+                        item.action = ACTIONS.save;
+                        items.push(item);
+                    }
+                }
+                if (calendarEvent.noMoreRecurrent && hasExistingRecurrence && calendarEvent.noMoreRecurrence) {
+                    recurrentCalendarEvents.forEach(function (cle) {
+                        if (cle._id !== calendarEvent._id) {
+                            let item = {'calEvent': cle, 'action': ACTIONS.delete};
+                            items.push(item);
+                        }
+                    });
+                }
+                if ((calendarEvent.detailToRecurrence ||
+                        calendarEvent.startDateToRecurrence ||
+                        calendarEvent.endDateToRecurrence) &&
+                    calendarEvent.parentId) {
+                    recurrentCalendarEvents.forEach(function (cle) {
+                        if (cle._id !== calendarEvent._id) {
+                            let save: boolean = false;
+                            if (calendarEvent.detailToRecurrence) {
+                                cle.title = calendarEvent.title;
+                                cle.description = calendarEvent.description;
+                                cle.location = calendarEvent.location;
+                                save = true;
+                            }
+                            if (calendarEvent.startDateToRecurrence
+                                && !calendarEvent.allday && !cle.allday
+                                && !moment(cle.startMoment).hours($scope.calendarEvent.startMoment.hours())
+                                    .minutes($scope.calendarEvent.startMoment.minutes()).isAfter(cle.endMoment, 'minute')) {
                                 cle.startMoment = moment(cle.startMoment)
                                     .hours(moment(calendarEvent.startTime).hours())
                                     .minutes(moment(calendarEvent.startTime).minutes());
                                 cle.startTime = calendarEvent.startTime;
                                 save = true;
-                    }
-                    if (calendarEvent.endDateToRecurrence
-                    && !calendarEvent.allday && !cle.allday
-                    && !moment(cle.endMoment).hours($scope.calendarEvent.endMoment.hours())
-                            .minutes($scope.calendarEvent.endMoment.minutes()).isBefore(cle.startMoment, 'minute')) {
-                        cle.endMoment = moment(cle.endMoment)
-                            .hours(moment(calendarEvent.endTime).hours())
-                            .minutes(moment(calendarEvent.endTime).minutes());
-                        cle.endTime = calendarEvent.endTime;
-                        save = true;
-                    }
-                    if (calendarEvent.allday && calendarEvent.editAllRecurrence) {
-                        cle.allday = true;
-                        save = true;
-                    } else if (!calendarEvent.allday && calendarEvent.editAllRecurrence){
-                        cle.allday = false;
-                        cle.startTime = calendarEvent.startTime;
-                        cle.endTime = calendarEvent.endTime;
-                        save = true;
-                    }
-                    if (save) {
-                        let item = {'calEvent': cle, 'action': ACTIONS.save};
-                        items.push(item);
-                    }
+                            }
+                            if (calendarEvent.endDateToRecurrence
+                                && !calendarEvent.allday && !cle.allday
+                                && !moment(cle.endMoment).hours($scope.calendarEvent.endMoment.hours())
+                                    .minutes($scope.calendarEvent.endMoment.minutes()).isBefore(cle.startMoment, 'minute')) {
+                                cle.endMoment = moment(cle.endMoment)
+                                    .hours(moment(calendarEvent.endTime).hours())
+                                    .minutes(moment(calendarEvent.endTime).minutes());
+                                cle.endTime = calendarEvent.endTime;
+                                save = true;
+                            }
+                            if (calendarEvent.allday && calendarEvent.editAllRecurrence) {
+                                cle.allday = true;
+                                save = true;
+                            } else if (!calendarEvent.allday && calendarEvent.editAllRecurrence) {
+                                cle.allday = false;
+                                cle.startTime = calendarEvent.startTime;
+                                cle.endTime = calendarEvent.endTime;
+                                save = true;
+                            }
+                            if (save) {
+                                let item = {'calEvent': cle, 'action': ACTIONS.save};
+                                items.push(item);
+                            }
+                        }
+                    });
                 }
-            });
-        }
-        await doItemCalendarEvent(items, 0);
-    };
+                await doItemCalendarEvent(items, 0);
+            };
 
-    $scope.cancelEventEdit = function(){
-        $scope.display.showEventPanel = undefined;
-    };
+            $scope.cancelEventEdit = function () {
+                $scope.display.showEventPanel = undefined;
+            };
 
-    $scope.cancelRecurrentEventEdit = (): void => {
-        $scope.display.showRecurrencePanel = undefined;
-    }
+            $scope.cancelRecurrentEventEdit = (): void => {
+                $scope.display.showRecurrencePanel = undefined;
+            }
 
-    $scope.switchSelectAllCalendarEvents = function() {
-        if ($scope.display.selectAllCalendarEvents) {
-            $scope.calendarEvents.filtered.forEach(function(calendarEvent) {
-                if ($scope.smallerRightEvent(calendarEvent) == "manage") {
-                    calendarEvent.selected = true;
+            $scope.switchSelectAllCalendarEvents = function () {
+                if ($scope.display.selectAllCalendarEvents) {
+                    $scope.calendarEvents.filtered.forEach(function (calendarEvent) {
+                        if ($scope.smallerRightEvent(calendarEvent) == "manage") {
+                            calendarEvent.selected = true;
+                        }
+                    });
+                } else {
+                    $scope.calendarEvents.deselectAll();
                 }
-            });
-        }
-        else {
-            $scope.calendarEvents.deselectAll();
-        }
-    };
+            };
 
-    $scope.switchFilterListByDates = function() {
-        $scope.calendarEvents.filters.startMoment = moment($scope.calendarEvents.filters.startMoment);
-        $scope.calendarEvents.filters.endMoment = moment($scope.calendarEvents.filters.endMoment);
-        $scope.calendarEvents.applyFilters();
-        $scope.calendarEvents.filtered = $scope.removeDuplicateCalendarEvent($scope.calendarEvents.filtered);
-        $scope.$apply();
-    };
+            $scope.switchFilterListByDates = function () {
+                $scope.calendarEvents.filters.startMoment = moment($scope.calendarEvents.filters.startMoment);
+                $scope.calendarEvents.filters.endMoment = moment($scope.calendarEvents.filters.endMoment);
+                $scope.calendarEvents.applyFilters();
+                $scope.calendarEvents.filtered = $scope.removeDuplicateCalendarEvent($scope.calendarEvents.filtered);
+                $scope.$apply();
+            };
 
-    $scope.closeRecurrence = function() {
-        $scope.display.calendarEventRecurrence = false;
-    };
+            $scope.closeRecurrence = function () {
+                $scope.display.calendarEventRecurrence = false;
+            };
 
-    $scope.nextWeekBookingButton = function() {
-        var nextStart = moment(model.calendarEvents.filters.startMoment).add(7, 'day');
-        var nextEnd = moment(model.calendarEvents.filters.endMoment).add(7, 'day');
-        updateCalendarList(nextStart,nextEnd);
-    };
+            $scope.nextWeekBookingButton = function () {
+                var nextStart = moment(model.calendarEvents.filters.startMoment).add(7, 'day');
+                var nextEnd = moment(model.calendarEvents.filters.endMoment).add(7, 'day');
+                updateCalendarList(nextStart, nextEnd);
+            };
 
-    $scope.previousWeekBookingButton = function() {
-        var prevStart = moment(model.calendarEvents.filters.startMoment).subtract(7, 'day');
-        var prevEnd = moment(model.calendarEvents.filters.endMoment).subtract(7, 'day');
-        updateCalendarList(prevStart,prevEnd);
-    };
+            $scope.previousWeekBookingButton = function () {
+                var prevStart = moment(model.calendarEvents.filters.startMoment).subtract(7, 'day');
+                var prevEnd = moment(model.calendarEvents.filters.endMoment).subtract(7, 'day');
+                updateCalendarList(prevStart, prevEnd);
+            };
 
-    $scope.switchCalendarEventTab = function(tab) {
-        if (tab === 'dates') {
-            $scope.calendarEvent.showRecurrence = false;
-            $scope.calendarEvent.showDetails = false;
-            $scope.calendarEvent.showDates = true;
-            $scope.showCalendarEventTimePicker = true;
+            $scope.switchCalendarEventTab = function (tab) {
+                if (tab === 'dates') {
+                    $scope.calendarEvent.showRecurrence = false;
+                    $scope.calendarEvent.showDetails = false;
+                    $scope.calendarEvent.showDates = true;
+                    $scope.showCalendarEventTimePicker = true;
 
-        } else if (tab === 'details') {
-            $scope.calendarEvent.showRecurrence = false;
-            $scope.calendarEvent.showDetails = true;
-            $scope.calendarEvent.showDates = false;
-            $scope.showCalendarEventTimePicker = false;
+                } else if (tab === 'details') {
+                    $scope.calendarEvent.showRecurrence = false;
+                    $scope.calendarEvent.showDetails = true;
+                    $scope.calendarEvent.showDates = false;
+                    $scope.showCalendarEventTimePicker = false;
 
-        } else if (tab === 'recurrence') {
-            $scope.calendarEvent.showRecurrence = true;
-            $scope.calendarEvent.showDetails = false;
-            $scope.calendarEvent.showDates = false;
-            $scope.showCalendarEventTimePicker = false;
-        }
-    };
+                } else if (tab === 'recurrence') {
+                    $scope.calendarEvent.showRecurrence = true;
+                    $scope.calendarEvent.showDetails = false;
+                    $scope.calendarEvent.showDates = false;
+                    $scope.showCalendarEventTimePicker = false;
+                }
+            };
 
-    /**
-     * Returns true if the event edition form is in the right format:
-     * areFieldsInCommonValid is true, it has a title, at least one calendar selected
-     * and the event end time is after the event start time.
-     * Depending on the case, more conditions can apply.
-     * @param actionButton the action of the button calling the method
-     */
-    $scope.isEventFormValid = (calendarEvent, actionButton: ActionButtonType) : boolean => {
-        if (!calendarEvent) {
-            return false;
-        }
+            /**
+             * Returns true if the event edition form is in the right format:
+             * areFieldsInCommonValid is true, it has a title, at least one calendar selected
+             * and the event end time is after the event start time.
+             * Depending on the case, more conditions can apply.
+             * @param actionButton the action of the button calling the method
+             */
+            $scope.isEventFormValid = (calendarEvent, actionButton: ActionButtonType): boolean => {
+                if (!calendarEvent) {
+                    return false;
+                }
 
-        $scope.eventForm = angular.element(document.getElementById("event-form")).scope();
-        /** Ensures that the fields of the form are correctly filled*/
-        let areFieldsInCommonValid = (!$scope.eventForm.form.$invalid && $scope.isCalendarSelectedInEvent()
-            && $scope.isTimeValid() && $scope.isDateValid() &&  $scope.areRecurrenceAndEventLengthsCompatible());
+                $scope.eventForm = angular.element(document.getElementById("event-form")).scope();
+                /** Ensures that the fields of the form are correctly filled*/
+                let areFieldsInCommonValid = (!$scope.eventForm.form.$invalid && $scope.isCalendarSelectedInEvent()
+                    && $scope.isTimeValid() && $scope.isDateValid() && $scope.areRecurrenceAndEventLengthsCompatible());
 
-        switch(actionButton) {
-            case ACTIONS.save:
-                /** Recurrent event cannot be saved if the "Delete other events from recurrence" checkbox is checked*/
-                return (areFieldsInCommonValid);
-            case ACTIONS.share:
-                /** Recurrent event can only be shared if the "Remove this event from recurrence" checkbox is checked*/
-                return (areFieldsInCommonValid && !(calendarEvent.isRecurrent && !calendarEvent.noMoreRecurrent)
-                    && !calendarEvent.editAllRecurrence);
-            case ACTIONS.delete:
-                /** Recurrent event can only be deleted in one of these cases:
-                 * "Edit this event only" and then check "Remove this event from recurrence"
-                 * "Edit all occurrences of this recurrence"
-                 */
-                return (!calendarEvent.isRecurrent || calendarEvent.editAllRecurrence || (calendarEvent.noMoreRecurrent
-                    && !calendarEvent.noMoreRecurrence));
-            default:
-                return false;
-        }
-    }
+                switch (actionButton) {
+                    case ACTIONS.save:
+                        /** Recurrent event cannot be saved if the "Delete other events from recurrence" checkbox is checked*/
+                        return (areFieldsInCommonValid);
+                    case ACTIONS.share:
+                        /** Recurrent event can only be shared if the "Remove this event from recurrence" checkbox is checked*/
+                        return (areFieldsInCommonValid && !(calendarEvent.isRecurrent && !calendarEvent.noMoreRecurrent)
+                            && !calendarEvent.editAllRecurrence);
+                    case ACTIONS.delete:
+                        /** Recurrent event can only be deleted in one of these cases:
+                         * "Edit this event only" and then check "Remove this event from recurrence"
+                         * "Edit all occurrences of this recurrence"
+                         */
+                        return (!calendarEvent.isRecurrent || calendarEvent.editAllRecurrence || (calendarEvent.noMoreRecurrent
+                            && !calendarEvent.noMoreRecurrence));
+                    default:
+                        return false;
+                }
+            }
 
-    /**
-     * Returns true if the event start time is before the event end time or if the event lasts all day
-     * or if the event lasts multiple days
-     */
-    $scope.isTimeValid = () : boolean => (($scope.calendarEvent.startTime && $scope.calendarEvent.endTime
-                && moment($scope.calendarEvent.startTime).isBefore(moment($scope.calendarEvent.endTime)))
+            /**
+             * Returns true if the event start time is before the event end time or if the event lasts all day
+             * or if the event lasts multiple days
+             */
+            $scope.isTimeValid = (): boolean => (($scope.calendarEvent.startTime && $scope.calendarEvent.endTime
+                    && moment($scope.calendarEvent.startTime).isBefore(moment($scope.calendarEvent.endTime)))
                 || $scope.calendarEvent.allday || !$scope.isOneDayEvent());
 
-    /**
-     * Returns true if the event start date is before or equal to the event end date
-     */
-    $scope.isDateValid = () : boolean => ($scope.calendarEvent.startMoment && $scope.calendarEvent.endMoment
-        && moment($scope.calendarEvent.startMoment).isValid() && moment($scope.calendarEvent.endMoment).isValid()
-        && moment($scope.calendarEvent.startMoment).isSameOrBefore(moment($scope.calendarEvent.endMoment), 'day'));
+            /**
+             * Returns true if the event start date is before or equal to the event end date
+             */
+            $scope.isDateValid = (): boolean => ($scope.calendarEvent.startMoment && $scope.calendarEvent.endMoment
+                && moment($scope.calendarEvent.startMoment).isValid() && moment($scope.calendarEvent.endMoment).isValid()
+                && moment($scope.calendarEvent.startMoment).isSameOrBefore(moment($scope.calendarEvent.endMoment), 'day'));
 
-    /**
-     * Returns true if the event length is shorter than the recurrence length
-     */
-    $scope.areRecurrenceAndEventLengthsCompatible = () : boolean => ($scope.isOneDayEvent() || !$scope.calendarEvent.isRecurrent
-        || ($scope.calendarEvent.recurrence.type == 'every_week'
-        && (moment($scope.calendarEvent.endMoment)
-                .diff(moment($scope.calendarEvent.startMoment), 'days')+1 <= $scope.calendarEvent.recurrence.every*7)));
+            /**
+             * Returns true if the event length is shorter than the recurrence length
+             */
+            $scope.areRecurrenceAndEventLengthsCompatible = (): boolean => ($scope.isOneDayEvent() || !$scope.calendarEvent.isRecurrent
+                || ($scope.calendarEvent.recurrence.type == 'every_week'
+                    && (moment($scope.calendarEvent.endMoment)
+                        .diff(moment($scope.calendarEvent.startMoment), 'days') + 1 <= $scope.calendarEvent.recurrence.every * 7)));
 
-    /**
-     * Returns true is the start and end date of the event are the same day or if one of them is not valid
-     * Events with invalid dates are treated like one day events
-     */
-    $scope.isOneDayEvent = () : boolean => ( !(moment($scope.calendarEvent.startMoment).isValid())
-        || !(moment($scope.calendarEvent.endMoment).isValid())
-        || (moment($scope.calendarEvent.startMoment).isSame(moment($scope.calendarEvent.endMoment), 'day')));
+            /**
+             * Returns true is the start and end date of the event are the same day or if one of them is not valid
+             * Events with invalid dates are treated like one day events
+             */
+            $scope.isOneDayEvent = (): boolean => (!(moment($scope.calendarEvent.startMoment).isValid())
+                || !(moment($scope.calendarEvent.endMoment).isValid())
+                || (moment($scope.calendarEvent.startMoment).isSame(moment($scope.calendarEvent.endMoment), 'day')));
 
-    /**
-     * Returns the date of the last day of the recurrence
-     * @param item an event of the recurrent
-     */
-    $scope.getEndOfRecurrence = (item : CalendarEvent) : String => {
-        let recurrenceEndDate : Moment = moment(item.endMoment);
-        $scope.calendarEvents.filtered.filter((event : CalendarEvent) => (event.parentId == item.parentId))
-            .forEach((recurrenceEvent : CalendarEvent) => {
-                if (DateUtils.isDateAfter(moment(recurrenceEvent.endMoment), recurrenceEndDate)){
-                    recurrenceEndDate = moment(recurrenceEvent.endMoment);
+            /**
+             * Returns the date of the last day of the recurrence
+             * @param item an event of the recurrent
+             */
+            $scope.getEndOfRecurrence = (item: CalendarEvent): String => {
+                let recurrenceEndDate: Moment = moment(item.endMoment);
+                $scope.calendarEvents.filtered.filter((event: CalendarEvent) => (event.parentId == item.parentId))
+                    .forEach((recurrenceEvent: CalendarEvent) => {
+                        if (DateUtils.isDateAfter(moment(recurrenceEvent.endMoment), recurrenceEndDate)) {
+                            recurrenceEndDate = moment(recurrenceEvent.endMoment);
+                        }
+                    });
+                return recurrenceEndDate.format(FORMAT.displayFRDate);
+            }
+
+            /**
+             * Returns the day of the week corresponding to the given number
+             * @param dayNumber number, the number of the day of the week (0 = sunday, 1 = monday ...)
+             */
+            $scope.getDayName = (dayNumber: DAY_OF_WEEK): String => {
+                return lang.translate(recurrence.fullDayMap[dayNumber]);
+            };
+
+
+            /**
+             * Returns a string of the days in which the weekly recurrence takes place
+             * @param item CalendarEvent, an event of the recurrence
+             */
+            $scope.getRecurrenceDays = (item: CalendarEvent): String => {
+                let recurrenceDaysList: String = "";
+                //add selected days to day list
+                Object.keys((<CalendarEventRecurrence>item.recurrence).week_days).forEach((key: string) => {
+                    if (((<CalendarEventRecurrence>item.recurrence).week_days[key])) {
+                        recurrenceDaysList = recurrenceDaysList.concat($scope.getDayName(Number(key)), ", ");
+                    }
+                });
+
+                return recurrenceDaysList;
+            };
+
+            /**
+             * Returns the name of the day of the week for the start or end date of an event.
+             * By default it returns the day of the start of the event.
+             * @param event CalendarEvent, the event we want the day of
+             * @param isMultiDayEvent boolean, if the event is multiple day or not
+             * @param isStartOrEnd whether we want the start or end date of the event
+             */
+            $scope.getDayOfWeek = (event: CalendarEvent, isMultiDayEvent: boolean, isStartOrEnd: "start" | "end"): String => {
+                let targetDay: Moment;
+                switch (isStartOrEnd) {
+                    case "start":
+                        targetDay = isMultiDayEvent ?
+                            $scope.calendarEvents.multiDaysEvents.find((e: CalendarEvent) => e._id == event._id).startMoment
+                            : event.startMoment;
+                        return $scope.getDayName(moment(targetDay).day());
+                    case "end":
+                        targetDay = isMultiDayEvent ?
+                            $scope.calendarEvents.multiDaysEvents.find((e: CalendarEvent) => e._id == event._id).endMoment
+                            : event.endMoment;
+                        return $scope.getDayName(moment(targetDay).day());
+                    default:
+                        return $scope.getDayName(moment(event.startMoment).day());
                 }
+            };
+
+            $scope.openAttachmentLightbox = (): void => {
+                $scope.display.attachmentLightbox = true;
+            };
+
+            /**
+             * Adds attachments to document and closes media-library lightbox
+             */
+            $scope.updateDocument = (): void => {
+                $scope.eventDocuments = angular.element(document.getElementsByTagName("media-library")).scope();
+                $scope.calendarEvent.attachments = $scope.calendarEvent.attachments ? $scope.calendarEvent.attachments : [];
+                if ($scope.eventDocuments.documents) {
+                    $scope.calendarEvent.attachments = [...$scope.calendarEvent.attachments, ...$scope.eventDocuments.documents];
+                }
+                $scope.display.attachmentLightbox = false;
+            };
+
+            $scope.removeDocumentFromAttachments = (documentId: String): void => {
+                let removedDocument: Document = $scope.calendarEvent.attachments.find((doc: Document) => doc._id == documentId);
+                $scope.calendarEvent.attachments.splice($scope.calendarEvent.attachments.indexOf(removedDocument), 1);
+            };
+
+            $scope.downloadAttachment = async (calendarEvent: CalendarEvent, attachment: Document): Promise<void> => {
+                let isUserAttachmentOwner: boolean = attachment.owner.userId != model.me.userId;
+                attachmentService.downloadAttachment(calendarEvent._id, attachment._id, isUserAttachmentOwner);
+            };
+
+            var updateCalendarList = function (start, end) {
+                model.calendarEvents.filters.startMoment.date(start.date());
+                model.calendarEvents.filters.startMoment.month(start.month());
+                model.calendarEvents.filters.startMoment.year(start.year());
+                model.calendarEvents.filters.endMoment.date(end.date());
+                model.calendarEvents.filters.endMoment.month(end.month());
+                model.calendarEvents.filters.endMoment.year(end.year());
+                $scope.calendarEvents.applyFilters();
+
+            };
+
+            $scope.$watch(
+                function () {
+                    return $('.hiddendatepickerform')[0]
+                        ? $('.hiddendatepickerform')[0].value
+                        : '';
+                },
+                function (newVal, oldVal) {
+                    if (newVal !== oldVal && !$scope.display.list &&
+                        newVal &&
+                        newVal !== '') {
+                        updateCalendarSchedule(moment(
+                            newVal,
+                            'DD/MM/YYYY'
+                        ).startOf('isoweek'));
+                    }
+
+                }
+            );
+
+            /**
+             * Sync elements when startMoment and endMoment are changed in the list view
+             */
+            $scope.$watchGroup(['calendarEvents.filters.startMoment','calendarEvents.filters.endMoment'], async (newValues, oldValues) => {
+                newValues[0] = moment(newValues[0]);
+                newValues[1] = moment(newValues[1]);
+                await $scope.calendars.syncSelectedCalendarEvents(newValues[0].format(FORMAT.formattedDate), newValues[1].format(FORMAT.formattedDate));
+                $scope.loadCalendarEvents();
+                template.open('calendar', 'events-list');
             });
-        return recurrenceEndDate.format(FORMAT.displayFRDate);
-    }
 
-    /**
-     * Returns the day of the week corresponding to the given number
-     * @param dayNumber number, the number of the day of the week (0 = sunday, 1 = monday ...)
-     */
-    $scope.getDayName = (dayNumber : DAY_OF_WEEK) : String => {
-        return lang.translate(recurrence.fullDayMap[dayNumber]);
-    };
+            const updateCalendarSchedule = (newDate) => {
+                model.calendar.firstDay.date(newDate.date());
+                model.calendar.firstDay.month(newDate.month());
+                model.calendar.firstDay.year(newDate.year());
+                $scope.calendar.calendarEvents.sync($scope.calendar, $scope.calendars);
+                $scope.calendarEvents.applyFilters();
+                template.open('calendar', 'read-calendar');
+                $('.hiddendatepickerform').datepicker('setValue', newDate.format(FORMAT.formattedDate)).datepicker('update');
+                $('.hiddendatepickerform').trigger({type: 'changeDate', date: newDate});
 
+            };
 
-    /**
-     * Returns a string of the days in which the weekly recurrence takes place
-     * @param item CalendarEvent, an event of the recurrence
-     */
-    $scope.getRecurrenceDays = (item : CalendarEvent) : String => {
-        let recurrenceDaysList : String = "";
-        //add selected days to day list
-        Object.keys((<CalendarEventRecurrence> item.recurrence).week_days).forEach((key: string) => {
-            if(((<CalendarEventRecurrence> item.recurrence).week_days[key])) {
-                recurrenceDaysList = recurrenceDaysList.concat($scope.getDayName(Number(key)), ", ");
-            }
-        });
-
-        return recurrenceDaysList;
-    };
-
-    /**
-     * Returns the name of the day of the week for the start or end date of an event.
-     * By default it returns the day of the start of the event.
-     * @param event CalendarEvent, the event we want the day of
-     * @param isMultiDayEvent boolean, if the event is multiple day or not
-     * @param isStartOrEnd whether we want the start or end date of the event
-     */
-    $scope.getDayOfWeek = (event : CalendarEvent, isMultiDayEvent : boolean, isStartOrEnd : "start"|"end") : String => {
-        let targetDay : Moment;
-        switch(isStartOrEnd) {
-            case "start":
-                targetDay = isMultiDayEvent ?
-                    $scope.calendarEvents.multiDaysEvents.find((e : CalendarEvent) => e._id == event._id).startMoment
-                    : event.startMoment;
-                return $scope.getDayName(moment(targetDay).day());
-            case "end":
-                targetDay = isMultiDayEvent ?
-                    $scope.calendarEvents.multiDaysEvents.find((e : CalendarEvent) => e._id == event._id).endMoment
-                    : event.endMoment;
-                return $scope.getDayName(moment(targetDay).day());
-            default:
-                return $scope.getDayName(moment(event.startMoment).day());
-        }
-    };
-
-    $scope.openAttachmentLightbox = () : void => {
-        $scope.display.attachmentLightbox = true;
-    };
-
-    /**
-     * Adds attachments to document and closes media-library lightbox
-     */
-    $scope.updateDocument = () : void => {
-        $scope.eventDocuments = angular.element(document.getElementsByTagName("media-library")).scope();
-        $scope.calendarEvent.attachments = $scope.calendarEvent.attachments? $scope.calendarEvent.attachments : [];
-        if($scope.eventDocuments.documents){
-            $scope.calendarEvent.attachments = [...$scope.calendarEvent.attachments, ...$scope.eventDocuments.documents];
-        }
-        $scope.display.attachmentLightbox = false;
-    };
-
-    $scope.removeDocumentFromAttachments = (documentId : String) : void => {
-        let removedDocument : Document = $scope.calendarEvent.attachments.find((doc : Document) => doc._id == documentId);
-        $scope.calendarEvent.attachments.splice($scope.calendarEvent.attachments.indexOf(removedDocument), 1);
-    };
-
-    $scope.downloadAttachment = async (calendarEvent: CalendarEvent, attachment: Document): Promise<void> => {
-        let isUserAttachmentOwner : boolean = attachment.owner.userId != model.me.userId;
-        attachmentService.downloadAttachment(calendarEvent._id, attachment._id, isUserAttachmentOwner);
-    };
-
-    var updateCalendarList = function(start, end){
-        model.calendarEvents.filters.startMoment.date(start.date());
-        model.calendarEvents.filters.startMoment.month(start.month());
-        model.calendarEvents.filters.startMoment.year(start.year());
-        model.calendarEvents.filters.endMoment.date(end.date());
-        model.calendarEvents.filters.endMoment.month(end.month());
-        model.calendarEvents.filters.endMoment.year(end.year());
-        $scope.calendarEvents.applyFilters();
-
-    };
-    $scope.$watch(
-        function() {
-            return $('.hiddendatepickerform')[0]
-                ? $('.hiddendatepickerform')[0].value
-                : '';
-        },
-        function(newVal, oldVal) {
-            if (newVal !== oldVal  &&  !$scope.display.list &&
-            newVal &&
-            newVal !== '' ){
-                updateCalendarSchedule(moment(
-                    newVal,
-                    'DD/MM/YYYY'
-                ).startOf('isoweek'));
-            }
-
-        });
-    var updateCalendarSchedule = function(newDate){
-        model.calendar.firstDay.date(newDate.date());
-        model.calendar.firstDay.month(newDate.month());
-        model.calendar.firstDay.year(newDate.year());
-        $scope.calendar.calendarEvents.sync($scope.calendar, $scope.calendars);
-        $scope.calendarEvents.applyFilters();
-            template.open('calendar', 'read-calendar');
-        $('.hiddendatepickerform').datepicker('setValue', newDate.format("DD/MM/YYYY")).datepicker('update');
-        $('.hiddendatepickerform').trigger({type: 'changeDate', date: newDate});
-
-    };
-}]);
+            const updateChangeDateCalendarSchedule = async function (newDate): Promise<void> {
+                model.calendar.firstDay.date(newDate.date());
+                model.calendar.firstDay.month(newDate.month());
+                model.calendar.firstDay.year(newDate.year());
+                await $scope.syncSelectedCalendars();
+                template.open('calendar', 'read-calendar');
+            };
+        }]);

--- a/src/main/resources/public/ts/core/enum/period-type.enum.ts
+++ b/src/main/resources/public/ts/core/enum/period-type.enum.ts
@@ -1,0 +1,5 @@
+export enum PERIODE_TYPE {
+    DAY = "day",
+    WEEK = "week",
+    MONTH = "month",
+}

--- a/src/main/resources/public/ts/model/Calendar.ts
+++ b/src/main/resources/public/ts/model/Calendar.ts
@@ -1,57 +1,59 @@
-import http from "axios";
-import { CalendarEvents } from "./";
+import http, {AxiosError, AxiosResponse} from "axios";
+import {CalendarEvents} from "./";
 import {Rights, notify, Shareable, Behaviours, _, idiom as lang, moment} from 'entcore';
-import { Mix, Selectable, Selection } from "entcore-toolkit";
+import {Mix, Selectable, Selection} from "entcore-toolkit";
+import {CalendarEventService, calendarEventService, calendarService} from "../services";
 
-export class Calendar implements Selectable, Shareable{
+export class Calendar implements Selectable, Shareable {
     _id: string;
     calendarEvents: CalendarEvents;
     selected: boolean;
     color: Array<string>;
     myRights: any;
-    shared:any;
-    owner:any;
+    shared: any;
+    owner: any;
     title: string;
     icsImport: any;
-    constructor(calendar?){
+
+    constructor(calendar?) {
         this.calendarEvents = new CalendarEvents(this);
         this.myRights = new Rights(this);
-        this.selected= false;
+        this.selected = false;
         if (!_.isEmpty(calendar)) {
             this.myRights.fromBehaviours();
-            Mix.extend(this,  Behaviours.applicationsBehaviours.calendar.resourceRights(calendar));
+            Mix.extend(this, Behaviours.applicationsBehaviours.calendar.resourceRights(calendar));
         }
     }
 
-    async save () {
-        if (this._id){
+    async save() {
+        if (this._id) {
             await this.update();
-        }
-        else {
+        } else {
             await this.create();
         }
     };
 
-    async create (){
+    async create() {
         let {data} = await http.post('/calendar/calendars', this);
         this._id = data._id;
     };
 
-    async update (){
+    async update() {
         await http.put('/calendar/' + this._id, this);
     }
 
-     async delete () {
+    async delete() {
         await http.delete('/calendar/' + this._id);
     };
 
-    toJSON (){
+    toJSON() {
         return {
             title: this.title,
             color: this.color,
         }
     };
-    async importIcal (icalToInput){
+
+    async importIcal(icalToInput) {
         try {
             let {data} = await http.put('/calendar/' + this._id + '/ical', icalToInput);
             this.icsImport = data;
@@ -59,7 +61,7 @@ export class Calendar implements Selectable, Shareable{
                 calendarEvent.startMoment = moment(calendarEvent.startMoment);
                 calendarEvent.endMoment = moment(calendarEvent.endMoment);
             });
-        } catch(e){
+        } catch (e) {
             notify.error(lang.translate("calendar.notify.icsImportError"));
         }
     }
@@ -67,40 +69,61 @@ export class Calendar implements Selectable, Shareable{
 
 export class Calendars extends Selection<Calendar> {
     behaviours: string;
-    preference : Preference;
+    preference: Preference;
     all: Array<Calendar>;
 
-    constructor(){
+    constructor() {
         super([]);
-        this.behaviours= 'calendar';
+        this.behaviours = 'calendar';
         this.preference = new Preference();
     }
 
-    async sync(){
+    async syncCalendars(): Promise<void> {
+        await calendarService.fetchCalendars()
+            .then((calendars: Array<Calendar>) => this.all = calendars)
+            .catch((e: AxiosError) => notify.error(lang.translate("calendar.notify.sync.calendars.error")));
+    }
+
+    async sync(): Promise<void> {
         let {data} = await http.get('/calendar/calendars');
         this.all = [];
-        _.map(data, (calendar)=> {
+        _.map(data, (calendar) => {
             let myCalendar = new Calendar(calendar);
             this.all.push(myCalendar);
         });
         await this.syncCalendarEvents();
     }
 
-     async syncCalendarEvents () {
-        for( let i = 0 ; i < this.all.length ; i++){
-           await this.all[i].calendarEvents.sync(this.all[i], this);
-         }
+    async syncCalendarEvents(): Promise<void> {
+        for (let i = 0; i < this.all.length; i++) {
+            await this.all[i].calendarEvents.sync(this.all[i], this);
+        }
     }
 
+    /**
+     * Synchronise elements depending on the display
+     * @param startDate define the beginning date of the range from which to select the events (is coptional)
+     * @param endDate define the end date of the range from which to select the events (is coptional)
+     */
+    async syncSelectedCalendarEvents(startDate?: string, endDate?: string): Promise<void> {
+        const promises: Promise<void>[] = [];
+        let selectedCalendars: Calendar[] = this.all.filter(cal => cal.selected);
+        selectedCalendars.forEach((cal: Calendar) => {
+            promises.push(cal.calendarEvents.sync(cal, this, startDate, endDate));
+        })
+        await Promise.all(promises);
+    }
 }
 
 export class Preference {
-    selectedCalendars : Array<string>;
-    async sync () {
+    selectedCalendars: Array<string>;
+
+    async sync() {
         let {data} = await http.get('/userbook/preference/calendar');
-        Mix.extend(this,JSON.parse(data.preference)) ;
+        Mix.extend(this, JSON.parse(data.preference));
     };
-    async update(){
+
+    async update() {
         http.put('/userbook/preference/calendar', {selectedCalendars: this.selectedCalendars});
     }
 }

--- a/src/main/resources/public/ts/model/CalendarEvent.ts
+++ b/src/main/resources/public/ts/model/CalendarEvent.ts
@@ -6,6 +6,7 @@ import { Mix, Selectable, Selection } from "entcore-toolkit";
 import {getTime, makerFormatTimeInput, utcTime} from './Utils'
 import {multiDaysEventsUtils} from "../utils/multiDaysEventsUtils";
 import {FORMAT} from "../core/const/date-format";
+import {calendarEventService, CalendarEventService} from "../services/calendar-event.service";
 
 export class CalendarEvent implements Selectable, Shareable{
     _id: String;
@@ -167,8 +168,8 @@ export class CalendarEvents extends Selection<CalendarEvent> {
         this.calendar = calendar;
     }
 
-    async sync (calendar, calendars){
-        let { data } = await http.get('/calendar/' + calendar._id+ '/events');
+    async sync (calendar, calendars, startDate?: string, endDate?: string): Promise<void> {
+        let { data } = await calendarEventService.fetchCalendarEvents(calendar._id, startDate, endDate);
         this.all = [];
         this.multiDaysEvents = [];
         data.forEach(event => this.all.push(new CalendarEvent(event)));

--- a/src/main/resources/public/ts/services/calendar-event.service.ts
+++ b/src/main/resources/public/ts/services/calendar-event.service.ts
@@ -1,0 +1,18 @@
+import {ng} from 'entcore'
+import http, {AxiosResponse} from "axios";
+
+export interface ICalendarEventService {
+    fetchCalendarEvents(calendarId: string, startDate?: string, endDate?: string): Promise<AxiosResponse>;
+}
+
+export const calendarEventService: ICalendarEventService = {
+    async fetchCalendarEvents(calendarId: string, startDate?: string, endDate?: string): Promise<AxiosResponse> {
+        let urlParam: string = '';
+        if (startDate && endDate) {
+            urlParam = `?startDate=${startDate}&endDate=${endDate}`;
+        }
+        return http.get(`/calendar/${calendarId}/events${urlParam}`);
+    }
+};
+
+export const CalendarEventService = ng.service('CalendarEventService', (): ICalendarEventService => calendarEventService);

--- a/src/main/resources/public/ts/services/calendar.service.ts
+++ b/src/main/resources/public/ts/services/calendar.service.ts
@@ -1,0 +1,16 @@
+import {ng} from 'entcore'
+import http, {AxiosResponse} from "axios";
+import {Calendar} from "../model";
+
+export interface ICalendarService {
+    fetchCalendars(): Promise<Array<Calendar>>;
+}
+
+export const calendarService: ICalendarService = {
+    fetchCalendars(): Promise<Array<Calendar>> {
+        return http.get(`/calendar/calendars`).then((response: AxiosResponse) =>
+            response.data.map(calendar => new Calendar(calendar)));
+    }
+};
+
+export const CalendarService = ng.service('CalendarService', (): ICalendarService => calendarService);

--- a/src/main/resources/public/ts/services/index.ts
+++ b/src/main/resources/public/ts/services/index.ts
@@ -1,1 +1,3 @@
 export * from './attachment.service';
+export * from './calendar-event.service';
+export * from './calendar.service';

--- a/src/test/java/net/atos/entng/calendar/services/EventServiceMongoImplTest.java
+++ b/src/test/java/net/atos/entng/calendar/services/EventServiceMongoImplTest.java
@@ -1,0 +1,61 @@
+package net.atos.entng.calendar.services;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import net.atos.entng.calendar.Calendar;
+import net.atos.entng.calendar.services.impl.EventServiceMongoImpl;
+import fr.wseduc.mongodb.MongoDb;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.entcore.common.user.UserInfos;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.mockito.Mockito.mock;
+
+@RunWith(VertxUnitRunner.class)
+public class EventServiceMongoImplTest {
+
+    private Vertx vertx;
+    private final MongoDb mongo = mock(MongoDb.class);
+    private EventServiceMongo eventService;
+    private ServiceFactory serviceFactory;
+
+    @Before
+    public void setUp(TestContext context) {
+        vertx = Vertx.vertx();
+        MongoDb.getInstance().init(vertx.eventBus(), "fr.openent.calendar");
+        serviceFactory = new ServiceFactory(vertx, null, null, mongo);
+        this.eventService = new EventServiceMongoImpl(Calendar.CALENDAR_COLLECTION, vertx.eventBus(), serviceFactory);
+    }
+
+    @Test
+    public void testListCalendarEvent_Should_ONLY_retrieve_calendar_by_ID(TestContext ctx) {
+        Async async = ctx.async();
+        String calendarId = "f2d55822-0816-47c0-9895-3864ec38bef9";
+        String startDate = "2022-05-04";
+        String endDate = "2022-05-07";
+        UserInfos user = new UserInfos();
+        user.setUserId("0eab1f72-f29d-4b7d-b82a-86f7c3efa6ed");
+        user.setGroupsIds(new ArrayList<>(
+                Arrays.asList("856b15ba-c61d-445e-9c81-8ef42f5dba7b",
+                        "70f366e6-048f-4fb3-93c9-a0b65d428924"))
+        );
+
+        String expectedCollection = "calendar";
+        String expectedMatcher = "{\"_id\":\"f2d55822-0816-47c0-9895-3864ec38bef9\"}";
+
+        vertx.eventBus().consumer("fr.openent.calendar", message -> {
+            JsonObject body = (JsonObject) message.body();
+            ctx.assertEquals(expectedCollection, body.getString("collection"));
+            ctx.assertEquals(expectedMatcher, body.getJsonObject("matcher").toString());
+            async.complete();
+        });
+        this.eventService.list(calendarId, user, startDate, endDate, null);
+    }
+
+}


### PR DESCRIPTION
## Describe your changes
Adding a lazy loading in order to upload events at every view change instead of uploading all events and calendars at the beginning
Improve performances

**_Second commit is only here to deploy on Jenkins_**

**Fichier controller.ts** 
Lignes changements effectués :
- 85-96
- 109-113
- 121-123
- 136-137
- 153-170
- 579
- 1708-1717
- 173-1737

## Checklist tests
- [ ] Create an event without deleting calendars or other events
- [ ] Change the view from day, to week, to month, to right or left that creates a request that lazy loads every events from selected calendars (request for each selected calendar)
- [ ] Modify a calendar without impacting the events associated with it
- [ ] Events from selected calendars must appear or disappear when those calendars are selected or unselected (request to fetch the calendar)

## Issue ticket number and link
fix(performance): #MC-69 lazy loading to fetch events
https://entsupport.gdapublic.fr/secure/RapidBoard.jspa?rapidView=99&projectKey=MC&view=detail&selectedIssue=MC-69&sprint=658

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequences regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [x] If it is a consequence feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to this project (must specify in **Description**)

