### PR TITLE
fix(imports): #MC-139 fix timezone hour offset

### DIFF
--- a/src/test/java/net/atos/entng/calendar/ical/ICalHandlerTest.java
+++ b/src/test/java/net/atos/entng/calendar/ical/ICalHandlerTest.java
@@ -1,19 +1,31 @@
 package net.atos.entng.calendar.ical;
 
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import net.atos.entng.calendar.exception.CalendarException;
 import net.atos.entng.calendar.exception.UnhandledEventException;
+import net.atos.entng.calendar.utils.DateUtils;
+import net.fortuna.ical4j.model.Calendar;
+import net.fortuna.ical4j.model.component.VEvent;
+import net.fortuna.ical4j.model.property.Uid;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockSettings;
 import org.mockito.Mockito;
 import org.powermock.reflect.Whitebox;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 @RunWith(VertxUnitRunner.class)
 public class ICalHandlerTest {
+
+
 
     @Test
     public void formatIcsDateTest(TestContext ctx) throws Exception {
@@ -50,6 +62,37 @@ public class ICalHandlerTest {
         } catch (UnhandledEventException e) {
             async.countDown();
         }
+    }
+
+    @Test
+    public void formatAllDayImportDateTest(TestContext ctx) throws Exception {
+        String expectedDateString = "2022-01-25T05:00:00.000Z";
+        net.fortuna.ical4j.model.Date startDate = new net.fortuna.ical4j.model.Date("20220125");
+        VEvent event = new VEvent(startDate, "title");
+        JsonObject jsonEvent = new JsonObject();
+
+
+        Whitebox.invokeMethod(new ICalHandler(), "setEventDates", event, jsonEvent);
+        ctx.assertEquals(expectedDateString, jsonEvent.getString("startMoment", null));
+    }
+
+    @Test
+    public void addAllDayEventTest(TestContext ctx) throws Exception {
+        Calendar calendar = new Calendar();
+        Date dateStart = new SimpleDateFormat(DateUtils.DATE_FORMAT).parse("2022-01-25T05:00:00.000Z");
+        Date dateEnd = new SimpleDateFormat(DateUtils.DATE_FORMAT).parse("2022-01-25T18:00:00.000Z");
+        net.fortuna.ical4j.model.Date start = new net.fortuna.ical4j.model.Date(dateStart.getTime());
+        net.fortuna.ical4j.model.Date end = new net.fortuna.ical4j.model.Date(dateEnd.getTime());
+        String title = "title";
+        String icsId = "000";
+
+        VEvent expectedEvent = new VEvent(start, end, "title");
+        Uid uid = new Uid();
+        uid.setValue(icsId);
+        expectedEvent.getProperties().add(uid);
+
+        Whitebox.invokeMethod(new ICalHandler(), "addAllDayEvent", calendar, start, end, title, icsId, null, null);
+        ctx.assertEquals(expectedEvent, calendar.getComponents().get(0));
     }
 
 }


### PR DESCRIPTION
## Describe your changes
all day imported events are saved from 5:00 utc (7:00 fr) to 18:00 utc (20:00 fr) (same flow as all day avents created within the module)
when all day events are exported they are from day1 00:00 utc to dayN+1 00:00.

## Checklist tests
import calendar with all day events (linked in ticket)
check dates in month and day view
export the same calendar and check dates again

## Issue ticket number and link
#MC-139 https://entsupport.gdapublic.fr/browse/MC-139

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [x] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

