### PR TITLE
fix(imports): #MC-149 fix special character when importing calendar

### DIFF
--- a/src/main/java/net/atos/entng/calendar/ical/ICalHandler.java
+++ b/src/main/java/net/atos/entng/calendar/ical/ICalHandler.java
@@ -207,17 +207,12 @@ public class ICalHandler extends AbstractVerticle implements Handler<Message<Jso
 
     private String encodeString(String toEncode) {
         Charset utf8charset = Charset.forName("UTF-8");
-        Charset iso88591charset = Charset.forName("ISO-8859-1");
 
         ByteBuffer inputBuffer = ByteBuffer.wrap(toEncode.getBytes());
 
         // decode UTF-8
         CharBuffer data = utf8charset.decode(inputBuffer);
-
-        // encode ISO-8559-1
-        ByteBuffer outputBuffer = iso88591charset.encode(data);
-        byte[] outputData = outputBuffer.array();
-        return new String(outputData);
+        return data.toString();
     }
 
     /**


### PR DESCRIPTION
## Describe your changes
fix special characters so that they are saved correctly (instead of saving � )

## Checklist tests
try to import calendar in which at leat 1 event has special characters (é, è, à ...)
check the formentionned event
try to export the calendar and check event again

## Issue ticket number and link
#MC-149 https://entsupport.gdapublic.fr/browse/MC-149

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

