### PR TITLE
fix(calendar): #MC-142 remove month view event creation possibility

### DIFF
--- a/src/main/resources/public/sass/global/components/calendar.scss
+++ b/src/main/resources/public/sass/global/components/calendar.scss
@@ -181,6 +181,10 @@ calendar {
     .calendar-current-week {
         max-height: unset;
     }
+
+    .day-number {
+        pointer-events: none !important;
+    }
 }
 
 h1 a {

--- a/src/main/resources/public/ts/controllers/controller.ts
+++ b/src/main/resources/public/ts/controllers/controller.ts
@@ -86,8 +86,10 @@ export const calendarController = ng.controller('CalendarController',
             this.$onInit = () => {
                 // Control opening of event lightbox
                 model.calendar.eventer.on("calendar.create-item", function (timeSlot) {
-                    window.bookingState = ACTIONS.create;
-                    $scope.createCalendarEvent($scope.calendarEvent, true);
+                    if (model.calendar.display.mode != "month") {
+                        window.bookingState = ACTIONS.create;
+                        $scope.createCalendarEvent($scope.calendarEvent, true);
+                    }
                 });
             };
 


### PR DESCRIPTION
## Describe your changes
User cannot create event by clicking on month view calendar (same behaviour as presences cdt and rbs)

## Checklist tests
try to create event by clicking on number in month view
check that the mouse does not change

## Issue ticket number and link
#MC-142 https://entsupport.gdapublic.fr/browse/MC-142

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

