### PR TITLE
fix(sniplet): #MC-122 fix sniplet surplus calls

### DIFF
--- a/src/main/resources/public/template/edit-event.html
+++ b/src/main/resources/public/template/edit-event.html
@@ -355,6 +355,7 @@
                     <sniplet
                             template="calendar-rbs-booking"
                             application="rbs"
+                            source="'editEvent'"
                             class="row">
                     </sniplet>
                 </div>

--- a/src/main/resources/public/template/view-event.html
+++ b/src/main/resources/public/template/view-event.html
@@ -91,6 +91,7 @@
             <sniplet
                     template="calendar-rbs-booking"
                     application="rbs"
+                    source="'viewEvent'"
                     class="row">
             </sniplet>
         </div>

--- a/src/main/resources/public/ts/controllers/controller.ts
+++ b/src/main/resources/public/ts/controllers/controller.ts
@@ -33,6 +33,7 @@ import {PERIODE_TYPE} from "../core/enum/period-type.enum";
 import {RbsEmitter} from "../model/rbs/rbs-emitter.model";
 import {IScope} from "angular";
 import {RBS_EVENTER} from "../core/enum/rbs/rbs-eventer.enum";
+import {RBS_SNIPLET} from "../core/const/rbs-sniplet.const";
 
 declare var ENABLE_RBS: boolean;
 declare let window: any;
@@ -717,8 +718,6 @@ export const calendarController = ng.controller('CalendarController',
                  }
             }
 
-            $scope.rbsEmitter.emitBookingInfo(RBS_EVENTER.INIT_BOOKING_INFOS, $scope.calendarEvent);
-
             if (($scope.hasManageRightOrIsEventOwner(calendarEvent) && $scope.hasRightOnSharedEvent(calendarEvent, rights.resources.updateEvent.right))
                 && calendarEvent.editAllRecurrence == undefined
                 && calendarEvent.isRecurrent && calendarEvent._id){
@@ -736,10 +735,10 @@ export const calendarController = ng.controller('CalendarController',
                 $scope.display.showRecurrencePanel = false;
                 template.close('recurrenceLightbox');
                 $scope.display.showEditEventPanel = true;
-                $scope.rbsEmitter.emitBookingInfo(RBS_EVENTER.CAN_EDIT_EVENT, true);
+                $scope.rbsEmitter.emitBookingInfo(RBS_EVENTER.INIT_BOOKING_INFOS, RBS_SNIPLET.editEventPanel, $scope.calendarEvent);
             } else {
                 $scope.display.showViewEventPanel = true;
-                $scope.rbsEmitter.emitBookingInfo(RBS_EVENTER.CAN_EDIT_EVENT, false);
+                $scope.rbsEmitter.emitBookingInfo(RBS_EVENTER.INIT_BOOKING_INFOS, RBS_SNIPLET.viewEventPanel, $scope.calendarEvent);
             }
         };
 
@@ -757,7 +756,7 @@ export const calendarController = ng.controller('CalendarController',
             $scope.display.showViewEventPanel = false;
             $scope.contentToWatch = "";
 
-            $scope.rbsEmitter.emitBookingInfo(RBS_EVENTER.CLOSE_BOOKING_INFOS);
+            $scope.rbsEmitter.emitBookingInfo(RBS_EVENTER.CLOSE_BOOKING_INFOS, RBS_SNIPLET.editEventPanel);
         };
 
             $scope.unselectRecurrenceRemovalCheckbox = (uncheckDeleteAllRecurrence: boolean): void => {

--- a/src/main/resources/public/ts/core/const/rbs-sniplet.const.ts
+++ b/src/main/resources/public/ts/core/const/rbs-sniplet.const.ts
@@ -1,0 +1,4 @@
+export const RBS_SNIPLET = {
+    editEventPanel: "editEvent",
+    viewEventPanel: "viewEvent"
+};

--- a/src/main/resources/public/ts/model/rbs/rbs-emitter.model.ts
+++ b/src/main/resources/public/ts/model/rbs/rbs-emitter.model.ts
@@ -1,8 +1,7 @@
 import {CalendarEvent} from "../CalendarEvent";
 import {_, angular, Behaviours, model, moment, Rights} from "entcore";
-import {Booking, Bookings, SavedBooking} from "./booking.model";
+import {Booking, SavedBooking} from "./booking.model";
 import {FORMAT} from "../../core/const/date-format";
-import {safeApply} from "../Utils";
 
 
 const rbsViewRight: string = "rbs.view";
@@ -16,16 +15,15 @@ export class RbsEmitter {
         this.ENABLE_RBS = ENABLE_RBS;
     }
 
-    emitBookingInfo = (event: string, data?: boolean|CalendarEvent): void => {
+    emitBookingInfo = (event: string, targetSniplet: string, data?: boolean|CalendarEvent): void => {
         if (this.ENABLE_RBS && !!model.me.authorizedActions.find((action) => action.displayName == rbsViewRight)) {
             switch (event) {
                 case Behaviours.applicationsBehaviours.rbs.eventerRbs.INIT_BOOKING_INFOS:
-                case Behaviours.applicationsBehaviours.rbs.eventerRbs.CAN_EDIT_EVENT:
                 case Behaviours.applicationsBehaviours.rbs.eventerRbs.UPDATE_BOOKING_INFOS:
-                    this.scope.$broadcast(event, data);
+                    this.scope.$broadcast(targetSniplet + event, data);
                     break;
                 case Behaviours.applicationsBehaviours.rbs.eventerRbs.CLOSE_BOOKING_INFOS:
-                    this.scope.$broadcast(event);
+                    this.scope.$broadcast(targetSniplet + event);
                     break;
             }
         }


### PR DESCRIPTION
## Describe your changes
the two instances of the sniplet are initialized at the same time as the module but when one is displayed information is sent to the opened sniplet

## Checklist tests
check ng2 console and network when using sniplet (changing date/resource type ...)

## Issue ticket number and link
#MC-122 https://entsupport.gdapublic.fr/browse/MC-122

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

