### PR TITLE
fix(calendar): #MC-46 restore right calendar's informations after cancel the modification

### DIFF
--- a/src/main/resources/public/ts/controllers/controller.ts
+++ b/src/main/resources/public/ts/controllers/controller.ts
@@ -917,6 +917,7 @@ export const calendarController = ng.controller('CalendarController',
 
             $scope.editCalendar = function (calendar, event) {
                 $scope.calendar = calendar;
+                $scope.calendarBeforeEdition = angular.copy(calendar);
                 event.stopPropagation();
                 template.open('calendar', 'edit-calendar');
                 $scope.createContentToWatch();
@@ -1003,14 +1004,19 @@ export const calendarController = ng.controller('CalendarController',
             };
 
             $scope.cancelCalendarEdit = function () {
-                $scope.calendarCreationScreen = false;
-                $scope.calendar = undefined;
-
                 if ($scope.isEmpty()) {
                     template.close('calendar');
                 } else {
+                    $scope.updateCalendars();
                     template.open('calendar', 'read-calendar');
+                    $scope.calendar = $scope.calendarBeforeEdition;
+                    let calendarElementSideBar = angular.element(document.getElementsByClassName("sidebar")).scope();
+                    if (calendarElementSideBar && calendarElementSideBar.vm && calendarElementSideBar.vm.calendar) {
+                        calendarElementSideBar.vm.calendar = $scope.calendarBeforeEdition;
+                        safeApply($scope);
+                    }
                 }
+
             };
 
             $scope.confirmRemoveCalendar = function (calendar, event) {


### PR DESCRIPTION
## Describe your changes
cancel is now working for calendar modification
Use updateCalendars to force update of the selected calendar and have informations before modifications and cancel.
## Checklist tests
☑︎ Restore the color of calendar before the start of modification
☑︎ Restore the right information of your calendar in modification view when you go again in it after cancel the modification
## Issue ticket number and link
https://entsupport.gdapublic.fr/browse/MC-46
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

