### PR TITLE
fix(sync): #MC-203 keep calendar selected when clicking on sync button

### DIFF
--- a/src/main/resources/public/ts/directives/calendar-item/calendar-item.html
+++ b/src/main/resources/public/ts/directives/calendar-item/calendar-item.html
@@ -6,5 +6,5 @@
            ng-model="vm.calendar.showButtons"
            ng-checked="vm.calendar.showButtons"
            ng-change="vm.hideOtherCalendarCheckboxes(vm.calendar)"/>
-    <i class="sync sidebar-title-calendar-display-sync top-spacing-small" ng-click="vm.updateExternalCalendar()"></i>
+    <i class="sync sidebar-title-calendar-display-sync top-spacing-small" ng-click="vm.updateExternalCalendar($event)"></i>
 </a>

--- a/src/main/resources/public/ts/directives/calendar-item/calendar-item.ts
+++ b/src/main/resources/public/ts/directives/calendar-item/calendar-item.ts
@@ -8,7 +8,7 @@ import {ICalendarService} from "../../services";
 interface IViewModel {
     onOpenOrCloseCalendar(calendar: Calendar, savePreferences: boolean): void;
     hideOtherCalendarCheckboxes(calendar: Calendar) : void;
-    updateExternalCalendar() : Promise<void>;
+    updateExternalCalendar($event: MouseEvent) : Promise<void>;
 }
 
 interface ICalendarItemProps {
@@ -41,7 +41,8 @@ class Controller implements ng.IController, IViewModel {
         this.$scope.$parent.$eval(this.$scope.vm.onUncheckOtherCalendarCheckboxes)(calendar);
     };
 
-    updateExternalCalendar = async (): Promise<void> => {
+    updateExternalCalendar = async ($event: MouseEvent): Promise<void> => {
+        $event.stopPropagation();
         await this.calendarService.updateExternalCalendar(this.$scope.vm.calendar);
     };
 }


### PR DESCRIPTION
## Describe your changes
when clicking in sync button it does not (un)select the calendar anymore

## Checklist tests
click on sync button

## Issue ticket number and link
#MC-203 https://jira.support-ent.fr/browse/MC-203

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

