### PR TITLE
feat(sync): #MC-220 handle external calendar sync waiting

### DIFF
--- a/src/main/resources/public/sass/global/components/_icons.scss
+++ b/src/main/resources/public/sass/global/components/_icons.scss
@@ -10,8 +10,12 @@ i {
   }
 
   &.sync::before {
-    font-family: 'calendar-material-icons';
     content: "\F04E6";
+    font-family: 'calendar-material-icons';
   }
 
+  &.loading::before {
+    content: '\e85a';
+    font-family: 'generic-icons';
+  }
 }

--- a/src/main/resources/public/sass/global/components/sidebar.scss
+++ b/src/main/resources/public/sass/global/components/sidebar.scss
@@ -14,6 +14,10 @@
         opacity: 1 !important;
       }
 
+      &-sync-in-progress {
+        text-indent: unset !important;
+      }
+
       &-center-text {
         text-align: center;
       }

--- a/src/main/resources/public/ts/directives/calendar-item/calendar-item.html
+++ b/src/main/resources/public/ts/directives/calendar-item/calendar-item.html
@@ -6,7 +6,8 @@
            ng-model="vm.calendar.showButtons"
            ng-checked="vm.calendar.showButtons"
            ng-change="vm.hideOtherCalendarCheckboxes(vm.calendar)"/>
-    <i class="sync sidebar-title-calendar-display-sync top-spacing-small" ng-click="vm.updateExternalCalendar($event)"></i>
+    <i class="sync sidebar-title-calendar-display-sync top-spacing-small" ng-click="vm.updateExternalCalendar($event)" ng-if="!vm.loading"></i>
+    <i class="loading sidebar-title-calendar-display-sync-in-progress" ng-if="vm.loading"></i>
     <span class="tooltip-top sidebar-title-calendar-display-center-text">
         <i18n>calendar.last.update</i18n>
         </br>

--- a/src/main/resources/public/ts/services/calendar.service.ts
+++ b/src/main/resources/public/ts/services/calendar.service.ts
@@ -7,6 +7,7 @@ export interface ICalendarService {
     fetchCalendars(): Promise<Array<Calendar>>;
     addExternalCalendar(calendar: Calendar): Promise<AxiosResponse>;
     updateExternalCalendar(calendar: Calendar): Promise<AxiosResponse>;
+    checkExternalCalendarSync(calendar: Calendar): Promise<AxiosResponse>;
 }
 
 export const calendarService: ICalendarService = {
@@ -21,6 +22,10 @@ export const calendarService: ICalendarService = {
 
     updateExternalCalendar(calendar: Calendar): Promise<AxiosResponse> {
         return http.put(`/calendar/${calendar._id}/url`);
+    },
+
+    checkExternalCalendarSync(calendar: Calendar): Promise<AxiosResponse> {
+        return http.get(`/calendar/${calendar._id}/url`);
     }
 };
 


### PR DESCRIPTION
## Describe your changes
Add loader when calendar is updated (icon becomes sync again when calendar is updated).
External calendar is updated on first arrival on the page/reload of the page + when sync icon is clicked.

First update check after 15s, then every minute

## Checklist tests
load calendar page. check that all calendars are loading and if the loading stops.
check the same after clicking on the sync button of one calendar.

## Issue ticket number and link
[MC-220](https://jira.support-ent.fr/browse/MC-220)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

