### PR TITLE
fix(icon): #MC-248 show loader if calendar is not selected

### DIFF
--- a/src/main/resources/public/sass/global/components/sidebar.scss
+++ b/src/main/resources/public/sass/global/components/sidebar.scss
@@ -16,6 +16,7 @@
 
       &-sync-in-progress {
         text-indent: unset !important;
+        opacity: 1 !important;
       }
 
       &-center-text {


### PR DESCRIPTION
## Describe your changes
loader icon does not disapear when calendar is not selected + mouse is not on calendar

## Checklist tests
unselect calendar and click on sync icon, then see if loader appears

## Issue ticket number and link
[MC-248](https://jira.support-ent.fr/browse/MC-248)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

