### PR TITLE
fix(sidebar): #MC-282 remove empty message when no external calendar rights

### DIFF
--- a/src/main/resources/public/ts/directives/side-bar/side-bar.html
+++ b/src/main/resources/public/ts/directives/side-bar/side-bar.html
@@ -73,11 +73,11 @@
                             <ul ng-if="!vm.hasSharedCalendars()"><li><i18n>calendar.calendars.empty</i18n></li></ul>
                         </li>
                         <!-- External calendars -->
-                        <li workflow="calendar.admin">
+                        <li workflow="calendar.admin" ng-if="vm.onCheckExternalCalendarRight('calendar.update')">
                             <ul class="colored">
-                                <h3 class="selected" ng-if="vm.onCheckExternalCalendarRight('calendar.update')"><i18n>calendar.external.calendars</i18n></h3>
+                                <h3 class="selected"><i18n>calendar.external.calendars</i18n></h3>
                                 <li ng-repeat="cl in vm.calendars.all | filter:vm.isExternalCalendar | orderBy: '+title'"
-                                    ng-if="vm.onCheckExternalCalendarRight('calendar.update') && vm.hasExternalCalendars()">
+                                    ng-if="vm.hasExternalCalendars()">
                                     <calendar-item calendar="cl"
                                                    on-open-or-close-clicked-calendar="vm.onOpenOrCloseCalendar"
                                                    on-uncheck-other-calendar-checkboxes="vm.hideOtherCalendarCheckboxes"


### PR DESCRIPTION
## Describe your changes
when external calendar rights are disabled, external calendar's empty state message no longer appears

## Checklist tests
Disable rights on account with no external calendars and check sidebar. Nothing from external calendar category should appear.
Enable rights and check if title + empty state message appear.

## Issue ticket number and link
[MC-282](https://jira.support-ent.fr/browse/MC-282)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

