### PR TITLE
fix(external): #MC-285 fix external calendar flow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ dependencies {
   compileOnly "io.vertx:vertx-core:$vertxVersion"
   compile "io.vertx:vertx-web-client:$vertxVersion"
   compile "org.entcore:common:$entCoreVersion"
-  compile "org.mnode.ical4j:ical4j:2.0.2"
+  compile "org.mnode.ical4j:ical4j:3.2.10"
   testCompile "io.vertx:vertx-unit:$vertxVersion"
   testCompile "junit:junit:$junitVersion"
   testCompile "org.entcore:tests:$entCoreVersion"
@@ -70,6 +70,7 @@ dependencies {
   testCompile "org.powermock:powermock-module-testng:$powerMockVersion"
   testCompile 'io.gatling.highcharts:gatling-charts-highcharts:2.2.2'
   testCompile "io.vertx:vertx-codegen:$vertxVersion"
+  testCompile "org.reflections:reflections:$reflectionsVersion"
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,6 +30,7 @@ toolsVersion=2.0.0-final
 junitVersion=4.10
 powerMockVersion=2.0.2
 mockitoVersion=2.+
+reflectionsVersion=0.10.2
 
 # compile lib
 entCoreVersion=4.8-SNAPSHOT

--- a/src/main/java/net/atos/entng/calendar/Calendar.java
+++ b/src/main/java/net/atos/entng/calendar/Calendar.java
@@ -72,6 +72,7 @@ public class Calendar extends BaseServer {
         vertx.deployVerticle(ICalHandler.class.getName(), new DeploymentOptions().setWorker(true).setConfig(config));
 
         setRepositoryEvents(new CalendarRepositoryEvents(vertx));
+        System.setProperty("ical4j.unfolding.relaxed", "true");
 
         if (config.getBoolean("searching-event", true)) {
             setSearchingEvents(new CalendarSearchingEvents());

--- a/src/main/java/net/atos/entng/calendar/core/enums/ErrorEnum.java
+++ b/src/main/java/net/atos/entng/calendar/core/enums/ErrorEnum.java
@@ -6,7 +6,10 @@ public enum ErrorEnum {
     PLATFORM_ALREADY_EXISTS("calendar.platform.already.exists"),
     ZIMBRA_NO_USER("zimbra.no.user"),
     ICAL_EVENTS_CREATED("ical.events.created"),
-    CALENDAR_ICAL_EVENT_CREATION_ERROR("calendar.ical.event.creation.error");
+    CALENDAR_ICAL_EVENT_CREATION_ERROR("calendar.ical.event.creation.error"),
+    CALENDAR_NOT_FOUND("calendar.not.found"),
+    COULD_NOT_GET_PLATFORM_CALENDAR("could.not.get.platform.calendar"),
+    NO_LOCAL_LANGUAGE("no.local.language");
 
     private final String errorEnum;
 

--- a/src/main/java/net/atos/entng/calendar/helpers/IModelHelper.java
+++ b/src/main/java/net/atos/entng/calendar/helpers/IModelHelper.java
@@ -1,0 +1,130 @@
+package net.atos.entng.calendar.helpers;
+
+import fr.wseduc.webutils.Either;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import net.atos.entng.calendar.models.IModel;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class IModelHelper {
+    private final static List<Class<?>> validJsonClasses = Arrays.asList(String.class, boolean.class, Boolean.class,
+            double.class, Double.class, float.class, Float.class, Integer.class, int.class, CharSequence.class,
+            JsonObject.class, JsonArray.class, Long.class, long.class);
+    private final static Logger log = LoggerFactory.getLogger(IModelHelper.class);
+
+    private IModelHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T extends IModel<T>> List<T> toList(JsonArray results, Class<T> modelClass) {
+        return results.stream()
+                .filter(JsonObject.class::isInstance)
+                .map(JsonObject.class::cast)
+                .map(iModel -> {
+                    try {
+                        return modelClass.getConstructor(JsonObject.class).newInstance(iModel);
+                    } catch (NoSuchMethodException | InstantiationException | IllegalAccessException |
+                             InvocationTargetException e) {
+                        return null;
+                    }
+                }).filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    public static JsonArray toJsonArray(List<? extends IModel<?>> dataList) {
+        return new JsonArray(dataList.stream().map(IModel::toJson).collect(Collectors.toList()));
+    }
+
+    /**
+     * Generic convert an {@link IModel} to {@link JsonObject}.
+     * Classes that do not implement any {@link #validJsonClasses} class or iModel implementation will be ignored.
+     * Except {@link List} and {@link Enum}
+     *
+     * @param ignoreNull If true ignore, fields that are null will not be put in the result
+     * @param iModel Instance of {@link IModel} to convert to {@link JsonObject}
+     * @return {@link JsonObject}
+     */
+    public static JsonObject toJson(IModel<?> iModel, boolean ignoreNull, boolean snakeCase) {
+        JsonObject statisticsData = new JsonObject();
+        final Field[] declaredFields = iModel.getClass().getDeclaredFields();
+        Arrays.stream(declaredFields).forEach(field -> {
+            boolean accessibility = field.isAccessible();
+            field.setAccessible(true);
+            try {
+                Object object = field.get(iModel);
+                String fieldName = snakeCase ? StringsHelper.camelToSnake(field.getName()) : field.getName();
+                if (object == null) {
+                    if (!ignoreNull) statisticsData.putNull(fieldName);
+                }
+                else if (object instanceof IModel) {
+                    statisticsData.put(fieldName, ((IModel<?>)object).toJson());
+                } else if (validJsonClasses.stream().anyMatch(aClass -> aClass.isInstance(object))) {
+                    statisticsData.put(fieldName, object);
+                } else if (object instanceof Enum) {
+                    statisticsData.put(fieldName, (Enum) object);
+                } else if (object instanceof List) {
+                    statisticsData.put(fieldName, listToJsonArray(((List<?>)object)));
+                }
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+            field.setAccessible(accessibility);
+        });
+        return statisticsData;
+    }
+
+    /**
+     * Generic convert a list of {@link Object} to {@link JsonArray}.
+     * Classes that do not implement any {@link #validJsonClasses} class or iModel implementation will be ignored.
+     * Except {@link List} and {@link Enum}
+     *
+     * @param objects List of object
+     * @return {@link JsonArray}
+     */
+    private static JsonArray listToJsonArray(List<?> objects) {
+        JsonArray res = new JsonArray();
+        objects.stream()
+                .filter(Objects::nonNull)
+                .forEach(object -> {
+                    if (object instanceof IModel) {
+                        res.add(((IModel<?>) object).toJson());
+                    }
+                    else if (validJsonClasses.stream().anyMatch(aClass -> aClass.isInstance(object))) {
+                        res.add(object);
+                    } else if (object instanceof Enum) {
+                        res.add((Enum)object);
+                    } else if (object instanceof List) {
+                        res.add(listToJsonArray(((List<?>) object)));
+                    }
+                });
+        return res;
+    }
+
+    public static <T extends IModel<T>> Handler<Either<String, JsonArray>> sqlResultToIModel(Promise<List<T>> promise, Class<T> modelClass) {
+        return sqlResultToIModel(promise, modelClass, null);
+    }
+
+    public static <T extends IModel<T>> Handler<Either<String, JsonArray>> sqlResultToIModel(Promise<List<T>> promise, Class<T> modelClass, String errorMessage) {
+        return event -> {
+            if (event.isLeft()) {
+                if (errorMessage != null) {
+                    log.error(errorMessage + " " + event.left().getValue());
+                }
+                promise.fail(event.left().getValue());
+            } else {
+                promise.complete(toList(event.right().getValue(), modelClass));
+            }
+        };
+    }
+}

--- a/src/main/java/net/atos/entng/calendar/helpers/StringsHelper.java
+++ b/src/main/java/net/atos/entng/calendar/helpers/StringsHelper.java
@@ -11,4 +11,15 @@ public class StringsHelper {
     public static boolean isNullOrEmpty( String target ) {
         return target == null || target.isEmpty();
     }
+
+    /**
+     * Convert a string in CamelCase to snake_case
+     */
+    public static String camelToSnake(String str)
+    {
+        if (str == null || str.isEmpty()) {
+            return "";
+        }
+        return str.replaceAll("\\B([A-Z])", "_$1").toLowerCase();
+    }
 }

--- a/src/main/java/net/atos/entng/calendar/ical/ICalHandler.java
+++ b/src/main/java/net/atos/entng/calendar/ical/ICalHandler.java
@@ -149,7 +149,6 @@ public class ICalHandler extends AbstractVerticle implements Handler<Message<Jso
         InputStream inputStream = new ByteArrayInputStream(icsContent.getBytes());
         JsonObject results = new JsonObject();
         try {
-            // Reader r = new InputStreamReader(inputStream, "ISO-8859-15");
             CalendarBuilder calendarBuilder = new CalendarBuilder();
             Calendar calendar = calendarBuilder.build(inputStream);
             JsonArray events = new JsonArray();

--- a/src/main/java/net/atos/entng/calendar/models/CalendarModel.java
+++ b/src/main/java/net/atos/entng/calendar/models/CalendarModel.java
@@ -3,10 +3,11 @@ package net.atos.entng.calendar.models;
 import io.vertx.core.json.JsonObject;
 import net.atos.entng.calendar.core.constants.Field;
 import net.atos.entng.calendar.core.constants.MongoField;
+import net.atos.entng.calendar.helpers.IModelHelper;
 
 import java.util.Date;
 
-public class CalendarModel {
+public class CalendarModel implements IModel<CalendarModel> {
 
 
     private final String id;
@@ -25,17 +26,18 @@ public class CalendarModel {
     public CalendarModel(JsonObject calendar) {
         this.id = calendar.getString(Field._ID, "");
         this.title = calendar.getString(Field.TITLE, "");
-        this.updated = new Date(calendar.getJsonObject(Field.UPDATED, new JsonObject()).getLong(MongoField.$DATE, null))
-                .toInstant().toString();
+
+        Long updateDate = calendar.getJsonObject(Field.UPDATED, new JsonObject()).getLong(MongoField.$DATE, null);
+        this.updated = (updateDate != null) ? new Date(updateDate).toInstant().toString() :  null;
+
         this.color = calendar.getString(Field.COLOR, null);
         this.owner = calendar.getJsonObject(Field.OWNER, new JsonObject());
         this.isExternal = calendar.getBoolean(Field.ISEXTERNAL, false);
-        this.icsLink = calendar.getString(Field.ICSLINK);
+        this.icsLink = calendar.getString(Field.ICSLINK, null);
         this.platform = calendar.getString(Field.PLATFORM, null);
         this.created = calendar.getJsonObject(Field.CREATED, new JsonObject());
         this.modified = calendar.getJsonObject(Field.MODIFIED, new JsonObject());
         this.isUpdating = calendar.getBoolean(Field.ISUPDATING, null);
-
 
     }
 
@@ -82,4 +84,14 @@ public class CalendarModel {
     public Boolean getIsUpdating() {
         return isUpdating;
     }
+
+    public JsonObject toJson() {
+        JsonObject calendarObject = IModelHelper.toJson(this, true, false);
+
+        calendarObject.put(Field._ID, this.id);
+        calendarObject.remove(Field.ID);
+
+        return calendarObject;
+    }
+
 }

--- a/src/main/java/net/atos/entng/calendar/models/IModel.java
+++ b/src/main/java/net/atos/entng/calendar/models/IModel.java
@@ -1,0 +1,14 @@
+package net.atos.entng.calendar.models;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * ⚠ Classes implementing this model must have a public constructor with JsonObject parameter
+ */
+public interface IModel<I extends IModel<I>> {
+    /**
+     * Convert object to jsonObject
+     * @return jsonObject
+     */
+    JsonObject toJson();
+}

--- a/src/main/java/net/atos/entng/calendar/services/impl/CalendarServiceImpl.java
+++ b/src/main/java/net/atos/entng/calendar/services/impl/CalendarServiceImpl.java
@@ -232,7 +232,6 @@ public class CalendarServiceImpl implements CalendarService {
                 log.error("[Calendar@CalendarService::update]: an error has occurred while updating calendar: ",
                         result.left().getValue());
                 promise.fail(result.left().getValue());
-                return;
             } else {
                 promise.complete();
             }

--- a/src/main/java/net/atos/entng/calendar/services/impl/EventServiceMongoImpl.java
+++ b/src/main/java/net/atos/entng/calendar/services/impl/EventServiceMongoImpl.java
@@ -50,6 +50,7 @@ import java.net.SocketException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.UUID;
 
 import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
 import static net.atos.entng.calendar.Calendar.CALENDAR_COLLECTION;
@@ -183,14 +184,8 @@ public class EventServiceMongoImpl extends MongoDbCrudService implements EventSe
         body.remove("_id");
 
         // ics Uid generate
-        UidGenerator uidGenerator;
-        String icsUid = "";
-        try {
-            uidGenerator = new UidGenerator("1");
-            icsUid = uidGenerator.generateUid().toString();
-        } catch (SocketException e) {
-            handler.handle(new Either.Left<String, JsonObject>(new String("Error")));
-        }
+        UUID uidGenerator = UUID.randomUUID();
+        String icsUid = uidGenerator.toString();
 
         // Prepare data
         JsonObject now = MongoDb.now();

--- a/src/main/resources/public/ts/directives/calendar-item/calendar-item.ts
+++ b/src/main/resources/public/ts/directives/calendar-item/calendar-item.ts
@@ -63,7 +63,7 @@ class Controller implements ng.IController, IViewModel {
         this.loading = true;
         safeApply(this.$scope);
         try {
-            await this.calendarService.updateExternalCalendar(this.$scope.vm.calendar);
+            if (this.calendarIsNotPlatformCreation()) await this.calendarService.updateExternalCalendar(this.$scope.vm.calendar);
             this.$timeout(() : IPromise<void> => {
                 this.calendarService.checkExternalCalendarSync(this.$scope.vm.calendar)
                     .then((r:AxiosResponse) => {
@@ -104,6 +104,10 @@ class Controller implements ng.IController, IViewModel {
             }
         }
     };
+
+    private calendarIsNotPlatformCreation() {
+        return this.$scope.vm.calendar.icsLink || (this.$scope.vm.calendar.platform && !!this.$scope.vm.calendar.updated);
+    }
 
     handleUpdateInterval = async (isSyncButton? : boolean): Promise<void> => {
         this.$interval(() : IPromise<void> => {

--- a/src/main/resources/public/ts/directives/external-calendar-form/external-calendar-form.html
+++ b/src/main/resources/public/ts/directives/external-calendar-form/external-calendar-form.html
@@ -20,14 +20,14 @@
 
                     <div class="">
                         <div class="row" >
-                            <input class="cell right-spacing-small top-spacing" ng-if="vm.enableZimbra" type="radio"
+                            <input class="cell right-spacing-small top-spacing" ng-if="vm.enableZimbra && vm.hasZimbraExpert()" type="radio"
                                    ng-click="vm.changeSelection('icsLink')" name="calendarOrigin" checked/>
                             <label class="cell"><i18n>calendar.external.from.url</i18n> &colon; </label>
                             <input class="six cell left-spacing" id="external-calendar-url-input"
                                    required ng-model="vm.calendar.icsLink"
                                    type="text" ng-pattern="/^(http[s]?:\/\/){0,1}(www\.){0,1}[a-zA-Z0-9\.\-]+\.[a-zA-Z]{2,5}[\.]{0,1}/"/>
                         </div>
-                        <div class="row" ng-if="vm.enableZimbra">
+                        <div class="row" ng-if="vm.enableZimbra && vm.hasZimbraExpert()">
                             <input class="cell right-spacing-small top-spacing" type="radio"
                                    ng-click="vm.changeSelection('platform', 'Zimbra')" name="calendarOrigin"
                                    ng-model="vm.calendar.platform" value="Zimbra"/>

--- a/src/main/resources/public/ts/directives/external-calendar-form/external-calendar-form.ts
+++ b/src/main/resources/public/ts/directives/external-calendar-form/external-calendar-form.ts
@@ -23,6 +23,7 @@ interface IViewModel extends ng.IController, IExternalCalendarFormProps {
     isFormComplete?(): boolean;
     changeSelection?(field: string, platform?: string): void;
     translate?(text: string): string;
+    hasZimbraExpert?(): boolean;
 }
 
 interface IExternalCalendarFormScope extends IScope {
@@ -70,6 +71,10 @@ class Controller implements IViewModel {
                 this.$scope.vm.calendar.icsLink = undefined;
                 break;
         }
+    }
+
+    hasZimbraExpert(): boolean {
+        return !!(model.me.authorizedActions.find(action => action.displayName == "zimbra.expert"));
     }
 
 }

--- a/src/main/resources/public/ts/utils/externalCalendarUtils.ts
+++ b/src/main/resources/public/ts/utils/externalCalendarUtils.ts
@@ -8,7 +8,7 @@ export class externalCalendarUtils {
      * Returns true if the calendar is external
      */
     static isCalendarExternal = (cal: Calendar): boolean => {
-        return !!(cal.isExternal && cal.icsLink);
+        return !!(cal.isExternal && (cal.icsLink || cal.platform));
     }
 
     /**

--- a/src/test/java/net/atos/entng/calendar/helper/IModelHelperTest.java
+++ b/src/test/java/net/atos/entng/calendar/helper/IModelHelperTest.java
@@ -1,0 +1,132 @@
+package net.atos.entng.calendar.helper;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import net.atos.entng.calendar.helpers.IModelHelper;
+import net.atos.entng.calendar.models.IModel;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.reflections.Reflections;
+
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.reflections.scanners.Scanners.SubTypes;
+
+@RunWith(VertxUnitRunner.class)
+public class IModelHelperTest {
+    enum MyEnum {
+        VALUE1,
+        VALUE2,
+        VALUE3
+    }
+
+    class MyClass {
+        public String id;
+    }
+    class MyIModel implements IModel<MyIModel> {
+        public String id;
+        public boolean isGood;
+        public MyOtherIModel otherIModel;
+        public MyClass myClass;
+        public List<Integer> typeIdList;
+        public List<MyOtherIModel> otherIModelList;
+        public List<MyClass> myClassList;
+        public List<List<JsonObject>> listList;
+        public MyEnum myEnum;
+        public List<MyEnum> myEnumList;
+        public MyEnum nullValue = null;
+
+        @Override
+        public JsonObject toJson() {
+            return IModelHelper.toJson(this, false, true);
+        }
+    }
+
+    class MyOtherIModel implements IModel<MyOtherIModel> {
+        public String myName;
+
+        @Override
+        public JsonObject toJson() {
+            return IModelHelper.toJson(this, false, true);
+        }
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(IModelHelperTest.class);
+
+    @Test
+    public void testSubClassIModel(TestContext ctx) {
+        Reflections reflections = new Reflections("net.atos.entng.calendar");
+        List<Class<?>> ignoredClassList = Arrays.asList(MyIModel.class, MyOtherIModel.class);
+
+        Set<Class<?>> subTypes =
+                reflections.get(SubTypes.of(IModel.class).asClass());
+        List<Class<?>> invalidModel = subTypes.stream()
+                .filter(modelClass -> !ignoredClassList.contains(modelClass))
+                .filter(modelClass -> {
+                    Constructor<?> emptyConstructor = Arrays.stream(modelClass.getConstructors())
+                            .filter(constructor -> constructor.getParameterTypes().length == 1
+                                    && constructor.getParameterTypes()[0].equals(JsonObject.class))
+                            .findFirst()
+                            .orElse(null);
+                    return emptyConstructor == null;
+                }).collect(Collectors.toList());
+
+        invalidModel.forEach(modelClass -> {
+            String message = String.format("[Calendar@%s::testSubClassIModel]: The class %s must have public constructor with JsonObject parameter declared",
+                    this.getClass().getSimpleName(), modelClass.getSimpleName());
+            log.fatal(message);
+        });
+
+        ctx.assertTrue(invalidModel.isEmpty(), "One or more IModel don't have public constructor with JsonObject parameter declared. Check log above.");
+    }
+
+    @Test
+    public void toJson(TestContext ctx) {
+        MyOtherIModel otherIModel1 = new MyOtherIModel();
+        otherIModel1.myName = "otherIModel1";
+        MyOtherIModel otherIModel2 = new MyOtherIModel();
+        otherIModel2.myName = "otherIModel2";
+        MyOtherIModel otherIModel3 = new MyOtherIModel();
+        otherIModel3.myName = "otherIModel3";
+
+        MyClass myClass1 = new MyClass();
+        myClass1.id = "myClass1";
+        MyClass myClass2 = new MyClass();
+        myClass2.id = "myClass2";
+        MyClass myClass3 = new MyClass();
+        myClass3.id = "myClass3";
+
+        MyIModel iModel = new MyIModel();
+        iModel.id = "id";
+        iModel.isGood = true;
+        iModel.typeIdList = Arrays.asList(1,2,3);
+        iModel.otherIModel = otherIModel1;
+        iModel.myClass = myClass1;
+        iModel.otherIModelList = Arrays.asList(otherIModel2, otherIModel3);
+        iModel.myClassList = Arrays.asList(myClass2, myClass3);
+
+        iModel.listList = Arrays.asList(Arrays.asList(new JsonObject().put("uuid", "uuid1"), new JsonObject().put("uuid", "uuid2")),
+                Arrays.asList(new JsonObject().put("uuid", "uuid3"), new JsonObject().put("uuid", "uuid4")),
+                Arrays.asList(new JsonObject().put("uuid", "uuid5"), new JsonObject().put("uuid", "uuid6")));
+
+        iModel.myEnum = MyEnum.VALUE1;
+        iModel.myEnumList = Arrays.asList(MyEnum.VALUE2, MyEnum.VALUE3);
+
+        String expected = "{\"id\":\"id\",\"is_good\":true,\"other_i_model\":{\"my_name\":\"otherIModel1\"}," +
+                "\"type_id_list\":[1,2,3],\"other_i_model_list\":[{\"my_name\":\"otherIModel2\"},{\"my_name\":\"otherIModel3\"}]," +
+                "\"my_class_list\":[],\"list_list\":[[{\"uuid\":\"uuid1\"},{\"uuid\":\"uuid2\"}],[{\"uuid\":\"uuid3\"}," +
+                "{\"uuid\":\"uuid4\"}],[{\"uuid\":\"uuid5\"},{\"uuid\":\"uuid6\"}]],\"my_enum\":\"VALUE1\"," +
+                "\"my_enum_list\":[\"VALUE2\",\"VALUE3\"],\"null_value\":null}";
+        ctx.assertEquals(expected, iModel.toJson().toString());
+
+        System.out.println();
+    }
+}
+


### PR DESCRIPTION
## Describe your changes
- can only create 1 calendar of each external platform
- front loader stops when eb from zimbra is received
- ical parsing fixed

## Checklist tests
for both platform and link external calendar:
- create calendar
- update calendar
then :
- sync calendars
- try to create 2nd Zimbra calendar

## Issue ticket number and link
[MC-285](https://jira.support-ent.fr/browse/MC-285)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

