### PR TITLE
fix(import): #MC-284 fix one day event import

### DIFF
--- a/src/main/java/net/atos/entng/calendar/core/enums/ErrorEnum.java
+++ b/src/main/java/net/atos/entng/calendar/core/enums/ErrorEnum.java
@@ -9,7 +9,8 @@ public enum ErrorEnum {
     CALENDAR_ICAL_EVENT_CREATION_ERROR("calendar.ical.event.creation.error"),
     CALENDAR_NOT_FOUND("calendar.not.found"),
     COULD_NOT_GET_PLATFORM_CALENDAR("could.not.get.platform.calendar"),
-    NO_LOCAL_LANGUAGE("no.local.language");
+    NO_LOCAL_LANGUAGE("no.local.language"),
+    END_DATE_BEFORE_START_DATE("end.date.before.start.date");
 
     private final String errorEnum;
 

--- a/src/test/java/net/atos/entng/calendar/ical/ICalHandlerTest.java
+++ b/src/test/java/net/atos/entng/calendar/ical/ICalHandlerTest.java
@@ -71,7 +71,7 @@ public class ICalHandlerTest {
         JsonObject jsonEvent = new JsonObject();
 
 
-        Whitebox.invokeMethod(new ICalHandler(), "setEventDates", event, jsonEvent);
+        Whitebox.invokeMethod(new ICalHandler(), "setEventDates", event, jsonEvent, new JsonObject());
         ctx.assertEquals(expectedDateString, jsonEvent.getString("startMoment", null));
     }
 


### PR DESCRIPTION
## Describe your changes
Calendar import does not produce invalid events (events with end date before start date) anymore.

Will be delivered with the following request:
```
db.getCollection('calendarevent').remove({"$expr" : {"$gte" :["$startMoment", "$endMoment"]}})
```

## Checklist tests
import the ics present in the ticket, two events should appear (YYYY/MM/DD french time) : 
2023/07/08 from 7:00 to 20:00
2023/05/22 from 7:00 to 20:00
[Zone-C-test.txt](https://github.com/OPEN-ENT-NG/calendar/files/11935175/Zone-C-test.txt)

## Issue ticket number and link
[MC-284](https://jira.support-ent.fr/browse/MC-284)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

