### PR TITLE
fix: #MC-295 fix my apps popup index

### DIFF
--- a/src/main/resources/public/ts/controllers/controller.ts
+++ b/src/main/resources/public/ts/controllers/controller.ts
@@ -924,7 +924,7 @@ export const calendarController = ng.controller('CalendarController',
                 template.close('lightbox');
                 await $scope.calendars.syncCalendarEvents();
                 await $scope.loadCalendarEvents();
-                addCssOnHtmlElement("body > portal > div > section", "z-index", "9000");
+                addCssOnHtmlElement("body > portal > div > section", "z-index", "1000");
                 $scope.$apply();
             };
 


### PR DESCRIPTION
## Describe your changes
When you close the modification popup, an index 9000 is placed on the content of the page. The application popup has a z-index of 1070 which poses a display problem.

## Checklist tests
Go to the calendar. Open then close the event creation pop-up window. When hovering over 'My Apps', the pop-up window displays correctly above the page content.

## Issue ticket number and link
https://jira.support-ent.fr/browse/MC-295

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

