### PR TITLE
fix(sync): #MC-294 fix events hiding on external calendar sync

### DIFF
--- a/src/main/resources/public/ts/controllers/controller.ts
+++ b/src/main/resources/public/ts/controllers/controller.ts
@@ -565,8 +565,8 @@ export const calendarController = ng.controller('CalendarController',
                 let updatedCalendar: Calendar = await calendarService.fetchCalendarById(calendar);
                 if (updatedCalendar._id) {
                     $scope.calendars.all.find((cl: Calendar) => (cl._id == updatedCalendar._id)).updated = updatedCalendar.updated;
-                    await $scope.calendars.syncSelectedCalendarEvents($scope.calendarEvents.filters.startMoment.format(FORMAT.formattedDate),
-                        $scope.calendarEvents.filters.endMoment.format(FORMAT.formattedDate));
+                    await $scope.syncSelectedCalendars();
+
                     $scope.loadCalendarEvents();
                     safeApply($scope);
                 }


### PR DESCRIPTION
## Describe your changes
Update external calendar events with startDate startig at first day of the selected view (day, week or month) instead of strating at the current day.

## Checklist tests

## Issue ticket number and link
MC-294 : https://jira.support-ent.fr/browse/MC-294

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

