### PR TITLE
fix(calendarEvent): #MC-297 disable save button when too old start date and too far end date

### DIFF
--- a/src/main/java/net/atos/entng/calendar/core/constants/Field.java
+++ b/src/main/java/net/atos/entng/calendar/core/constants/Field.java
@@ -76,6 +76,14 @@ public class Field {
     public static final String recurrence = "recurrence";
     // event recurrence type (every day/every week)
     public static final String type = "type";
+    public static final String end_type = "end_type";
+    public static final String on = "on";
+    public static final String after = "after";
+    public static final String end_on = "end_on";
+    public static final String end_after = "end_after";
+    public static final int end_after_max_value = 365;
+    public static final int end_after_min_value = 1;
+
     // event recurrence type option
     public static final String every_week = "every_week";
     // event recurrence length (1, 2, 3 ... days/week)

--- a/src/main/java/net/atos/entng/calendar/core/constants/Field.java
+++ b/src/main/java/net/atos/entng/calendar/core/constants/Field.java
@@ -40,6 +40,9 @@ public class Field {
     public static final String STARTMOMENT = "startMoment";
     // event end moment
     public static final String ENDMOMENT = "endMoment";
+
+    public static final String REFSTARTDATE = "2000-01-01T00:00:00.000Z";
+    public static final int REFENDDATE = 80;
     // calendars
     public static final String CALENDARS = "calendars";
     public static final String CALENDAR = "calendar";

--- a/src/main/java/net/atos/entng/calendar/helpers/EventHelper.java
+++ b/src/main/java/net/atos/entng/calendar/helpers/EventHelper.java
@@ -115,55 +115,52 @@ public class EventHelper extends MongoDbControllerHelper {
 
     @Override
     public void create(final HttpServerRequest request) {
-        UserUtils.getUserInfos(eb, request, new Handler<UserInfos>() {
-            @Override
-            public void handle(final UserInfos user) {
-                final String calendarId = request.params().get(CALENDAR_ID_PARAMETER);
-                if (user != null) {
-                    RequestUtils.bodyToJson(request, (Handler<JsonObject>) object -> {
-                        calendarService.hasExternalCalendarId(object.getJsonArray("calendar")
-                                        .stream().map((Object::toString))
-                                        .collect(Collectors.toList()))
-                                .onSuccess(isExternal -> {
-                                    if(Boolean.FALSE.equals(isExternal)) {
-                                        if (isEventValid(object, request)) {
-                                            RbsHelper.saveBookingsInRbs(request, object, user, config, eb).onComplete(e ->
-                                                    eventService.create(calendarId, object, user, event -> {
-                                                        if (event.isRight()) {
-                                                            JsonObject eventId = event.right().getValue();
-                                                            final JsonObject message = new JsonObject();
-                                                            message.put(Field._ID, calendarId);
-                                                            message.put(Field.EVENTID, eventId.getString("_id"));
-                                                            message.put(Field.START_DATE, (String) null);
-                                                            message.put(Field.END_DATE, (String) null);
-                                                            message.put(Field.SENDNOTIF, object.getBoolean(Field.SENDNOTIF, null));
-                                                            notifyEventCreatedOrUpdated(request, user, message, true);
-                                                            renderJson(request, event.right().getValue(), 200);
-                                                            eventHelper.onCreateResource(request, RESOURCE_NAME);
-                                                        } else if (event.isLeft()) {
-                                                            log.error("[Calendar@EventHelper::create] Error when getting notification informations.");
-                                                        }
-                                                    })
-                                            );
+        UserUtils.getUserInfos(eb, request, user -> {
+            final String calendarId = request.params().get(CALENDAR_ID_PARAMETER);
+            if (user != null) {
+                RequestUtils.bodyToJson(request, object -> {
+                    calendarService.hasExternalCalendarId(object.getJsonArray("calendar")
+                                    .stream().map((Object::toString))
+                                    .collect(Collectors.toList()))
+                            .onSuccess(isExternal -> {
+                                if(Boolean.FALSE.equals(isExternal)) {
+                                    if (isEventValid(object)) {
+                                        RbsHelper.saveBookingsInRbs(request, object, user, config, eb).onComplete(e ->
+                                                eventService.create(calendarId, object, user, event -> {
+                                                    if (event.isRight()) {
+                                                        JsonObject eventId = event.right().getValue();
+                                                        final JsonObject message = new JsonObject();
+                                                        message.put(Field._ID, calendarId);
+                                                        message.put(Field.EVENTID, eventId.getString("_id"));
+                                                        message.put(Field.START_DATE, (String) null);
+                                                        message.put(Field.END_DATE, (String) null);
+                                                        message.put(Field.SENDNOTIF, object.getBoolean(Field.SENDNOTIF, null));
+                                                        notifyEventCreatedOrUpdated(request, user, message, true);
+                                                        renderJson(request, event.right().getValue(), 200);
+                                                        eventHelper.onCreateResource(request, RESOURCE_NAME);
+                                                    } else if (event.isLeft()) {
+                                                        log.error("[Calendar@EventHelper::create] Error when getting notification informations.");
+                                                    }
+                                                })
+                                        );
 
-                                        } else {
-                                            log.error(String.format("[Calendar@EventHelper::create] " + "Submitted event is not valid"),
-                                                    I18n.getInstance().translate("calendar.error.date.saving", getHost(request), I18n.acceptLanguage(request)));
-                                            Renders.unauthorized(request);
-                                        }
                                     } else {
-                                        unauthorized(request);
+                                        log.error(String.format("[Calendar@EventHelper::create] " + "Submitted event is not valid"),
+                                                I18n.getInstance().translate("calendar.error.date.saving", getHost(request), I18n.acceptLanguage(request)));
+                                        Renders.unauthorized(request);
                                     }
-                                })
-                                .onFailure(err -> {
-                                    renderError(request);
-                                });
+                                } else {
+                                    unauthorized(request);
+                                }
+                            })
+                            .onFailure(err -> {
+                                renderError(request);
+                            });
 
-                    });
-                } else {
-                    log.debug("User not found in session.");
-                    Renders.unauthorized(request);
-                }
+                });
+            } else {
+                log.debug("User not found in session.");
+                Renders.unauthorized(request);
             }
         });
     }
@@ -182,22 +179,28 @@ public class EventHelper extends MongoDbControllerHelper {
                             isExternalCalendarEventImmutable(eventId)
                                     .onSuccess(isExternal -> {
                                         if(Boolean.FALSE.equals(isExternal)) {
-                                            crudService.update(eventId, object, user, new Handler<Either<String, JsonObject>>() {
-                                                public void handle(Either<String, JsonObject> event) {
-                                                    if (event.isRight()) {
-                                                        final JsonObject message = new JsonObject();
-                                                        message.put("id", calendarId);
-                                                        message.put("eventId", eventId);
-                                                        message.put("start_date", (String) null);
-                                                        message.put("end_date", (String) null);
-                                                        message.put("sendNotif", object.containsKey("sendNotif") ? object.getBoolean("sendNotif") : null);
-                                                        notifyEventCreatedOrUpdated(request, user, message, false);
-                                                        renderJson(request, event.right().getValue(), 200);
-                                                    } else if (event.isLeft()) {
-                                                        log.error("Error when getting notification informations.");
+                                            if (isEventValid(object)) {
+                                                crudService.update(eventId, object, user, new Handler<Either<String, JsonObject>>() {
+                                                    public void handle(Either<String, JsonObject> event) {
+                                                        if (event.isRight()) {
+                                                            final JsonObject message = new JsonObject();
+                                                            message.put("id", calendarId);
+                                                            message.put("eventId", eventId);
+                                                            message.put("start_date", (String) null);
+                                                            message.put("end_date", (String) null);
+                                                            message.put("sendNotif", object.containsKey("sendNotif") ? object.getBoolean("sendNotif") : null);
+                                                            notifyEventCreatedOrUpdated(request, user, message, false);
+                                                            renderJson(request, event.right().getValue(), 200);
+                                                        } else if (event.isLeft()) {
+                                                            log.error("Error when getting notification informations.");
+                                                        }
                                                     }
-                                                }
-                                            });
+                                                });
+                                            } else {
+                                                log.error(String.format("[Calendar@EventHelper::update] " + "Submitted event is not valid"),
+                                                        I18n.getInstance().translate("calendar.error.date.saving", getHost(request), I18n.acceptLanguage(request)));
+                                                Renders.unauthorized(request);
+                                            }
                                         } else {
                                             unauthorized(request);
                                         }
@@ -516,29 +519,61 @@ public class EventHelper extends MongoDbControllerHelper {
      * and the recurrence must be at least weekly
      *
      * @param object  JsonObject, the event to save
-     * @param request HttpServerRequest, the saving request
      * @return true if the event meets the requirements mentionned before
      */
-    private boolean isEventValid(JsonObject object, HttpServerRequest request) {
+    private boolean isEventValid(JsonObject object) {
+        if(!object.containsKey(Field.STARTMOMENT) || !object.containsKey(Field.ENDMOMENT)) return false;
+
         Date startDate = DateUtils.parseDate(object.getString(Field.STARTMOMENT), DateUtils.DATE_FORMAT_UTC);
         Date endDate = DateUtils.parseDate(object.getString(Field.ENDMOMENT), DateUtils.DATE_FORMAT_UTC);
+
+        if(startDate == null || endDate == null)return false;
+
         Date refStartDate = DateUtils.parseDate(Field.REFSTARTDATE, DateUtils.DATE_FORMAT_UTC);
         Date refEndDate = DateUtils.getRefEndDate();
 
-        boolean areDatesValid = DateUtils.isStrictlyBefore(startDate, endDate);
-        boolean isStartMomentNotToOld = DateUtils.isStrictlyAfter(startDate, refStartDate);
-        boolean isEndMomentNotToFar = DateUtils.isStrictlyAfter(startDate, refEndDate);
+        boolean isStartMomentNotTooOld = DateUtils.isStrictlyAfter(startDate, refStartDate);
+        boolean isEndMomentNotTooFar = DateUtils.isStrictlyBefore(endDate, refEndDate);
         boolean isOneDayEvent = DateUtils.isSameDay(startDate, endDate);
         boolean isNotRecurrentEvent = Boolean.FALSE.equals(object.getBoolean(Field.isRecurrent));
+        boolean areDatesValid = DateUtils.isStrictlyBefore(startDate, endDate) && isStartMomentNotTooOld && isEndMomentNotTooFar && isRecurrentEndDateValid(object);
 
         long dayInMilliseconds = 1000 * 60 * 60 * 24;
         int eventDayLength = (int) ((endDate.getTime() - startDate.getTime()) / dayInMilliseconds);
 
         boolean isWeeklyRecurrenceValid = object.getValue(Field.recurrence) instanceof JsonObject
-                && "every_week".equals(object.getJsonObject(Field.recurrence).getValue(Field.type))
+                && Field.every_week.equals(object.getJsonObject(Field.recurrence).getValue(Field.type))
                 && (eventDayLength < (7 * object.getJsonObject(Field.recurrence).getInteger(Field.every)));
 
-        return (areDatesValid && isStartMomentNotToOld && isEndMomentNotToFar && (isOneDayEvent || isNotRecurrentEvent || isWeeklyRecurrenceValid));
+
+        return (areDatesValid && (isOneDayEvent || isNotRecurrentEvent || isWeeklyRecurrenceValid));
+    }
+
+
+    /**
+     * Check if a recurrent event has valid end date.
+     * If it has an end date, it must be earlier than the current date + 80 years
+     * If it's a number of recureence type of event : this number should be less than 100
+     * @param object  JsonObject, the event to save
+     * @return true if the recurrence meets the requirements mentionned before
+     */
+    private boolean isRecurrentEndDateValid (JsonObject object) {
+        Date refEndDate = DateUtils.getRefEndDate();
+        if (Boolean.FALSE.equals(object.getBoolean(Field.isRecurrent))) {
+            return true;
+        } else {
+            boolean result = false;
+            String endType = (String) object.getJsonObject(Field.recurrence).getValue(Field.end_type);
+            if (Field.on.equals(endType)) {
+                String endOnString = (String) object.getJsonObject(Field.recurrence).getValue(Field.end_on);
+                Date endOnDate = DateUtils.parseDate(endOnString, DateUtils.DATE_FORMAT_UTC);
+                result = DateUtils.isStrictlyBefore(endOnDate, refEndDate);
+            } else if (Field.after.equals(endType)) {
+                int endAfterValue = (int) object.getJsonObject(Field.recurrence).getValue(Field.end_after);
+                result =  endAfterValue >= Field.end_after_min_value && endAfterValue <= Field.end_after_max_value;
+            }
+            return result;
+        }
     }
 
     /**

--- a/src/main/java/net/atos/entng/calendar/helpers/EventHelper.java
+++ b/src/main/java/net/atos/entng/calendar/helpers/EventHelper.java
@@ -522,8 +522,12 @@ public class EventHelper extends MongoDbControllerHelper {
     private boolean isEventValid(JsonObject object, HttpServerRequest request) {
         Date startDate = DateUtils.parseDate(object.getString(Field.STARTMOMENT), DateUtils.DATE_FORMAT_UTC);
         Date endDate = DateUtils.parseDate(object.getString(Field.ENDMOMENT), DateUtils.DATE_FORMAT_UTC);
+        Date refStartDate = DateUtils.parseDate(Field.REFSTARTDATE, DateUtils.DATE_FORMAT_UTC);
+        Date refEndDate = DateUtils.getRefEndDate();
 
         boolean areDatesValid = DateUtils.isStrictlyBefore(startDate, endDate);
+        boolean isStartMomentNotToOld = DateUtils.isStrictlyAfter(startDate, refStartDate);
+        boolean isEndMomentNotToFar = DateUtils.isStrictlyAfter(startDate, refEndDate);
         boolean isOneDayEvent = DateUtils.isSameDay(startDate, endDate);
         boolean isNotRecurrentEvent = Boolean.FALSE.equals(object.getBoolean(Field.isRecurrent));
 
@@ -534,7 +538,7 @@ public class EventHelper extends MongoDbControllerHelper {
                 && "every_week".equals(object.getJsonObject(Field.recurrence).getValue(Field.type))
                 && (eventDayLength < (7 * object.getJsonObject(Field.recurrence).getInteger(Field.every)));
 
-        return (areDatesValid && (isOneDayEvent || isNotRecurrentEvent || isWeeklyRecurrenceValid));
+        return (areDatesValid && isStartMomentNotToOld && isEndMomentNotToFar && (isOneDayEvent || isNotRecurrentEvent || isWeeklyRecurrenceValid));
     }
 
     /**

--- a/src/main/java/net/atos/entng/calendar/utils/DateUtils.java
+++ b/src/main/java/net/atos/entng/calendar/utils/DateUtils.java
@@ -1,5 +1,7 @@
 package net.atos.entng.calendar.utils;
 
+import net.atos.entng.calendar.core.constants.Field;
+
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -38,6 +40,13 @@ public final class DateUtils {
         return (d1.before(d2));
     }
 
+    public static Boolean isStrictlyAfter(Date d1, Date d2) {
+        if ((d1 == null) || (d2 == null)) {
+            return false;
+        }
+        return (d1.after(d2));
+    }
+
     public static Boolean isSameDay(Date d1, Date d2) {
         if ((d1 == null) || (d2 == null)) {
             return false;
@@ -60,6 +69,14 @@ public final class DateUtils {
         String dateString = dateFormat.format(date);
 
         return dateString;
+    }
+
+    public static Date getRefEndDate() {
+        Date currentDate = new Date();
+        final Calendar cal = new GregorianCalendar();
+        cal.setTime(currentDate);
+        cal.add(Calendar.YEAR, Field.REFENDDATE);
+        return cal.getTime();
     }
 
 

--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -128,6 +128,8 @@
     "calendar.error.booking.saving": "Saving error for one or more bookings",
     "calendar.error.time": "The end time must be after the start time.",
     "calendar.error.date": "The end time must be after of equal to the start time.",
+    "calendar.error.date.old": "Start date must be after January 1, 2000",
+    "calendar.error.date.far": "The end date must be within the next 80 years from the current date",
     "calendar.delete.error": "Default calendar cannot be deleted",
     "calendar.navigation.guard": "Les modifications que vous avez apportées ne seront peut-être pas enregistrées. Souhaitez vous quitter cette page?",
     "calendar.event.save.and.restrict": "Save and restrict",

--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -130,6 +130,7 @@
     "calendar.error.date": "The end time must be after of equal to the start time.",
     "calendar.error.date.old": "Start date must be after January 1, 2000",
     "calendar.error.date.far": "The end date must be within the next 80 years from the current date",
+    "calendar.error.date.recurrence": "The end date of recurrence is not valid",
     "calendar.delete.error": "Default calendar cannot be deleted",
     "calendar.navigation.guard": "Les modifications que vous avez apportées ne seront peut-être pas enregistrées. Souhaitez vous quitter cette page?",
     "calendar.event.save.and.restrict": "Save and restrict",

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -121,6 +121,8 @@
     "calendar.error.booking.saving": "Problème d'enregistrement de la ou des réservations",
     "calendar.error.time": "L'heure de fin doit être supérieure à l'heure de début.",
     "calendar.error.date": "La date de fin doit être supérieure ou égale à la date de début.",
+    "calendar.error.date.old": "La date de début doit être supérieure au 1 janvier 2000",
+    "calendar.error.date.far": "La date de fin doit être dans les 80 prochaines années à partir de la date actuelle",
     "calendar.delete.error": "Une erreur est survenue lors de la supression du calendrier",
     "calendar.navigation.guard": "Les modifications que vous avez apportées ne seront peut-être pas enregistrées. Souhaitez vous quitter cette page?",
     "calendar.event.not.all.calendar.rights": "Vous n'avez pas les droits de modification sur cet évènement.",

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -123,6 +123,7 @@
     "calendar.error.date": "La date de fin doit être supérieure ou égale à la date de début.",
     "calendar.error.date.old": "La date de début doit être supérieure au 1 janvier 2000",
     "calendar.error.date.far": "La date de fin doit être dans les 80 prochaines années à partir de la date actuelle",
+    "calendar.error.date.recurrence": "La date de fin de récurrence n'est pas valide",
     "calendar.delete.error": "Une erreur est survenue lors de la supression du calendrier",
     "calendar.navigation.guard": "Les modifications que vous avez apportées ne seront peut-être pas enregistrées. Souhaitez vous quitter cette page?",
     "calendar.event.not.all.calendar.rights": "Vous n'avez pas les droits de modification sur cet évènement.",

--- a/src/main/resources/public/template/edit-event.html
+++ b/src/main/resources/public/template/edit-event.html
@@ -169,6 +169,12 @@
                             <div class="top-spacing-twice warning form-element" ng-if="!isDateValid()">
                                 <i18n>calendar.error.date</i18n>
                             </div>
+                            <div class="top-spacing-twice info form-element" ng-if="isStartDateToOld()">
+                                <i18n>calendar.error.date.old</i18n>
+                            </div>
+                            <div class="top-spacing-twice info form-element" ng-if="isEndDateToFar()">
+                                <i18n>calendar.error.date.far</i18n>
+                            </div>
                         </div>
                     </div>
                 </article>

--- a/src/main/resources/public/template/edit-event.html
+++ b/src/main/resources/public/template/edit-event.html
@@ -169,10 +169,10 @@
                             <div class="top-spacing-twice warning form-element" ng-if="!isDateValid()">
                                 <i18n>calendar.error.date</i18n>
                             </div>
-                            <div class="top-spacing-twice info form-element" ng-if="isStartDateToOld()">
+                            <div class="top-spacing-twice info form-element" ng-if="isStartDateTooOld()">
                                 <i18n>calendar.error.date.old</i18n>
                             </div>
-                            <div class="top-spacing-twice info form-element" ng-if="isEndDateToFar()">
+                            <div class="top-spacing-twice info form-element" ng-if="isEndDateTooFar()">
                                 <i18n>calendar.error.date.far</i18n>
                             </div>
                         </div>
@@ -352,6 +352,9 @@
                             </div>
                             <div class="top-spacing-twice warning form-element" ng-if="!areRecurrenceAndEventLengthsCompatible()">
                                 <i18n>calendar.event.length.error</i18n>
+                            </div>
+                            <div class="top-spacing-twice warning form-element" ng-if="!isValidRecurrentEndDate()">
+                                <i18n>calendar.error.date.recurrence</i18n>
                             </div>
                         </div>
                     </div>

--- a/src/main/resources/public/ts/controllers/controller.ts
+++ b/src/main/resources/public/ts/controllers/controller.ts
@@ -85,7 +85,8 @@ export const calendarController = ng.controller('CalendarController',
             $scope.ENABLE_RBS = ENABLE_RBS;
             $scope.rbsEmitter = new RbsEmitter($scope, !!$scope.ENABLE_RBS);
             $scope.ENABLE_ZIMBRA = ENABLE_ZIMBRA;
-            $scope.minDate = moment().clone().subtract(2, 'years');
+            $scope.minDate = moment('2000-01-01');
+            $scope.maxDate = moment().add(80, 'years').startOf('day');
 
                 template.open('main', 'main-view');
                 template.open('top-menu', 'top-menu');
@@ -285,9 +286,6 @@ export const calendarController = ng.controller('CalendarController',
 
 
         $scope.changeStartMoment = () => {
-            if($scope.calendarEvent.startMoment < $scope.minDate){
-                $scope.calendarEvent.startMoment = $scope.minDate;
-            }
             if (!$scope.isDateValid()) {
                 $scope.calendarEvent.endMoment = moment($scope.calendarEvent.startMoment);
             } else {
@@ -1667,7 +1665,7 @@ export const calendarController = ng.controller('CalendarController',
                 $scope.eventForm = angular.element(document.getElementById("event-form")).scope();
                 /** Ensures that the fields of the form are correctly filled*/
                 let areFieldsInCommonValid: boolean = ($scope.rbsEmitter.checkBookingValidAndSendInfoToSniplet() && !$scope.eventForm.editEvent.$invalid && $scope.isCalendarSelectedInEvent()
-                    && $scope.isTimeValid() && $scope.isDateValid() &&  $scope.areRecurrenceAndEventLengthsCompatible());
+                    && $scope.isTimeValid() && $scope.isDateValid() &&  $scope.areRecurrenceAndEventLengthsCompatible() && !$scope.isStartDateToOld() && !$scope.isEndDateToFar());
 
                 switch (actionButton) {
                     case ACTIONS.save:
@@ -1703,6 +1701,16 @@ export const calendarController = ng.controller('CalendarController',
             $scope.isDateValid = (): boolean => ($scope.calendarEvent.startMoment && $scope.calendarEvent.endMoment
                 && moment($scope.calendarEvent.startMoment).isValid() && moment($scope.calendarEvent.endMoment).isValid()
                 && moment($scope.calendarEvent.startMoment).isSameOrBefore(moment($scope.calendarEvent.endMoment), 'day'));
+
+            /**
+             * Returns true if startMoment is older than january 1/2000
+             */
+            $scope.isStartDateToOld = (): boolean => ($scope.calendarEvent.startMoment < $scope.minDate);
+
+            /**
+             * Returns true if endMoment is after 80 years further
+             */
+            $scope.isEndDateToFar = (): boolean => ($scope.calendarEvent.endMoment > $scope.maxDate);
 
             /**
              * Returns true if the event length is shorter than the recurrence length

--- a/src/main/resources/public/ts/controllers/controller.ts
+++ b/src/main/resources/public/ts/controllers/controller.ts
@@ -85,6 +85,7 @@ export const calendarController = ng.controller('CalendarController',
             $scope.ENABLE_RBS = ENABLE_RBS;
             $scope.rbsEmitter = new RbsEmitter($scope, !!$scope.ENABLE_RBS);
             $scope.ENABLE_ZIMBRA = ENABLE_ZIMBRA;
+            $scope.minDate = moment().clone().subtract(2, 'years');
 
                 template.open('main', 'main-view');
                 template.open('top-menu', 'top-menu');
@@ -282,7 +283,11 @@ export const calendarController = ng.controller('CalendarController',
                 });
             };
 
+
         $scope.changeStartMoment = () => {
+            if($scope.calendarEvent.startMoment < $scope.minDate){
+                $scope.calendarEvent.startMoment = $scope.minDate;
+            }
             if (!$scope.isDateValid()) {
                 $scope.calendarEvent.endMoment = moment($scope.calendarEvent.startMoment);
             } else {

--- a/src/main/resources/public/ts/controllers/controller.ts
+++ b/src/main/resources/public/ts/controllers/controller.ts
@@ -13,7 +13,7 @@ import {
     LANG_CALENDAR,
     rights,
     ACTIONS,
-    ActionButtonType
+    ActionButtonType, minStartMomentDate, maxEndMomentDate
 } from "../model/constantes";
 import {
     isSameAfter,
@@ -85,8 +85,8 @@ export const calendarController = ng.controller('CalendarController',
             $scope.ENABLE_RBS = ENABLE_RBS;
             $scope.rbsEmitter = new RbsEmitter($scope, !!$scope.ENABLE_RBS);
             $scope.ENABLE_ZIMBRA = ENABLE_ZIMBRA;
-            $scope.minDate = moment('2000-01-01');
-            $scope.maxDate = moment().add(80, 'years').startOf('day');
+            $scope.minDate = moment(minStartMomentDate);
+            $scope.maxDate = moment().add(maxEndMomentDate, 'years').startOf('day');
 
                 template.open('main', 'main-view');
                 template.open('top-menu', 'top-menu');

--- a/src/main/resources/public/ts/model/constantes/TIME.ts
+++ b/src/main/resources/public/ts/model/constantes/TIME.ts
@@ -66,3 +66,5 @@ export const recurrence = {
 };
 
 export const LANG_CALENDAR = "fr";
+export const minStartMomentDate = "2000-01-01";
+export const maxEndMomentDate = "80";


### PR DESCRIPTION
## Describe your changes
To prevent user from saving too long events and slow down the application, we now display a message and disable save button if the start date of event is too old (before january 1, 2000) or end date is more than in 80 years.
## Checklist tests
Create a new event and choose a date before 01 01 2000 or a end date after 2103
## Issue ticket number and link
[MC-297](https://jira.support-ent.fr/browse/MC-297)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

