### PR TITLE
fix: WB-3307, improve searching users from groups 

### DIFF
--- a/src/main/java/net/atos/entng/calendar/helpers/EventHelper.java
+++ b/src/main/java/net/atos/entng/calendar/helpers/EventHelper.java
@@ -639,27 +639,6 @@ public class EventHelper extends MongoDbControllerHelper {
 
                 + " UNION " +
 
-                "MATCH (n:ProfileGroup )<-[:IN]-(u:User) " +
-                "WHERE n.id IN ['" +
-                Joiner.on("','").join(shareIds) + "'] AND u.id <> {userId} " +
-                "RETURN distinct u.id as id"
-
-                + " UNION " +
-
-                "MATCH (n:ManualGroup )<-[:IN]-(u:User) " +
-                "WHERE n.id IN ['" +
-                Joiner.on("','").join(shareIds) + "'] AND u.id <> {userId} " +
-                "RETURN distinct u.id as id"
-
-                + " UNION " +
-
-                "MATCH (n:CommunityGroup )<-[:IN]-(u:User) " +
-                "WHERE n.id IN ['" +
-                Joiner.on("','").join(shareIds) + "'] AND u.id <> {userId} " +
-                "RETURN distinct u.id as id"
-
-                + " UNION " +
-
                 "MATCH (n:Group )<-[:IN]-(u:User) " +
                 "WHERE n.id IN ['" +
                 Joiner.on("','").join(shareIds) + "'] AND u.id <> {userId} " +

--- a/src/main/java/net/atos/entng/calendar/services/impl/DefaultUserServiceImpl.java
+++ b/src/main/java/net/atos/entng/calendar/services/impl/DefaultUserServiceImpl.java
@@ -65,24 +65,6 @@ public class DefaultUserServiceImpl implements UserService {
 
                 + " UNION " +
 
-                "MATCH (n:ProfileGroup )<-[:IN]-(u:User) " +
-                "WHERE n.id IN {ids} " + (keepUserFromSession ? "" : "AND u.id <> {userId} ") +
-                "RETURN distinct u.id as id, u.displayName as displayName"
-
-                + " UNION " +
-
-                "MATCH (n:ManualGroup )<-[:IN]-(u:User) " +
-                "WHERE n.id IN {ids} " + (keepUserFromSession ? "" : "AND u.id <> {userId} ") +
-                "RETURN distinct u.id as id, u.displayName as displayName"
-
-                + " UNION " +
-
-                "MATCH (n:CommunityGroup )<-[:IN]-(u:User) " +
-                "WHERE n.id IN {ids} " + (keepUserFromSession ? "" : "AND u.id <> {userId} ") +
-                "RETURN distinct u.id as id, u.displayName as displayName"
-
-                + " UNION " +
-
                 "MATCH (n:Group )<-[:IN]-(u:User) " +
                 "WHERE n.id IN {ids} " + (keepUserFromSession ? "" : "AND u.id <> {userId} ") +
                 "RETURN distinct u.id as id, u.displayName as displayName";

--- a/src/test/java/net/atos/entng/calendar/services/DefaultUserServiceImplTest.java
+++ b/src/test/java/net/atos/entng/calendar/services/DefaultUserServiceImplTest.java
@@ -50,24 +50,6 @@ public class DefaultUserServiceImplTest {
 
                 + " UNION " +
 
-                "MATCH (n:ProfileGroup )<-[:IN]-(u:User) " +
-                "WHERE n.id IN {ids} AND u.id <> {userId} " +
-                "RETURN distinct u.id as id, u.displayName as displayName"
-
-                + " UNION " +
-
-                "MATCH (n:ManualGroup )<-[:IN]-(u:User) " +
-                "WHERE n.id IN {ids} AND u.id <> {userId} " +
-                "RETURN distinct u.id as id, u.displayName as displayName"
-
-                + " UNION " +
-
-                "MATCH (n:CommunityGroup )<-[:IN]-(u:User) " +
-                "WHERE n.id IN {ids} AND u.id <> {userId} " +
-                "RETURN distinct u.id as id, u.displayName as displayName"
-
-                + " UNION " +
-
                 "MATCH (n:Group )<-[:IN]-(u:User) " +
                 "WHERE n.id IN {ids} AND u.id <> {userId} " +
                 "RETURN distinct u.id as id, u.displayName as displayName";
@@ -95,24 +77,6 @@ public class DefaultUserServiceImplTest {
         JsonObject expectedUser = new JsonObject().put(Field.USERID, USER_ID).put(Field.IDS, groupIds);
         String expectedQuery = "MATCH (u:User) " +
                 "WHERE u.id IN {ids} " +
-                "RETURN distinct u.id as id, u.displayName as displayName"
-
-                + " UNION " +
-
-                "MATCH (n:ProfileGroup )<-[:IN]-(u:User) " +
-                "WHERE n.id IN {ids} " +
-                "RETURN distinct u.id as id, u.displayName as displayName"
-
-                + " UNION " +
-
-                "MATCH (n:ManualGroup )<-[:IN]-(u:User) " +
-                "WHERE n.id IN {ids} " +
-                "RETURN distinct u.id as id, u.displayName as displayName"
-
-                + " UNION " +
-
-                "MATCH (n:CommunityGroup )<-[:IN]-(u:User) " +
-                "WHERE n.id IN {ids} " +
                 "RETURN distinct u.id as id, u.displayName as displayName"
 
                 + " UNION " +


### PR DESCRIPTION
## Describe your changes
Suppression de "UNION MATCH" non nécessaires et ralentissant fortement la requête.
Non nécessaires car les groupes ciblés par ces "UNION MATCH" sont des sous-ensembles du label "Group".
On peut donc les retirer pour soulager la requête sans changer le nombre et la nature des résultats retournés.

## Checklist tests
Testé en préprod sur un cas de requête lente : 
![Capture d’écran 2024-09-11 à 11 00 52](https://github.com/user-attachments/assets/0f378d79-c9b1-41ae-9004-fd6dc92ce84a)

## Issue ticket number and link
https://edifice-community.atlassian.net/browse/WB-3307

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

